### PR TITLE
Implicit convert operator + call functions on Proxy/Object

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3,6 +3,7 @@ This this the changelog file for the Pothos C++ library.
 Release 0.6.0 (pending)
 ==========================
 
+- Automatic slots for all void calls in Block::registerCallable
 - Renamed the project repo from pothos to PothosCore
 - Updated toolkit/submodule URLs for repo rename
   - Renamed pothos-gui toolkit to PothosFlow

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3,7 +3,7 @@ This this the changelog file for the Pothos C++ library.
 Release 0.6.0 (pending)
 ==========================
 
-- API changes Pothos::Object
+- API changes to Object, Proxy, and Callable interface types
   * Object supports implicit templated convert to target type
   * Proxy supports implicit templated convert to target type
   * Deprecated Callable interface's callVoid(), use call()

--- a/include/Pothos/Config.hpp
+++ b/include/Pothos/Config.hpp
@@ -55,6 +55,8 @@
 #endif //_MSC_VER
 
 //deprecated macro for causing warnings on old calls
+#define POTHOS_DEPRECATED
+/*
 #if defined(__GNUC__)
 #define POTHOS_DEPRECATED __attribute__((deprecated))
 #elif defined(_MSC_VER)
@@ -63,6 +65,7 @@
 #pragma message("WARNING: You need to implement DEPRECATED for this compiler")
 #define POTHOS_DEPRECATED
 #endif
+*/
 
 /*!
  * The function tuple emits a string name + function pointer tuple.

--- a/include/Pothos/Framework/Block.hpp
+++ b/include/Pothos/Framework/Block.hpp
@@ -4,7 +4,7 @@
 /// This file contains the interface for creating custom Blocks.
 ///
 /// \copyright
-/// Copyright (c) 2014-2016 Josh Blum
+/// Copyright (c) 2014-2017 Josh Blum
 /// SPDX-License-Identifier: BSL-1.0
 ///
 
@@ -264,7 +264,9 @@ public:
 
     /*!
      * Export a function call on this block to set/get parameters.
-     * This call will automatically register a slot of the same name.
+     * This call will automatically register a slot of the same name
+     * when the call has a void return type and the name does not
+     * start with an underscore in which case its considered private.
      * \param name the name of the callable
      * \param call the bound callable method
      */

--- a/include/Pothos/Object/Object.hpp
+++ b/include/Pothos/Object/Object.hpp
@@ -4,7 +4,7 @@
 /// Object is intended to facilitate API polymorphism similar to java.
 ///
 /// \copyright
-/// Copyright (c) 2013-2016 Josh Blum
+/// Copyright (c) 2013-2017 Josh Blum
 /// SPDX-License-Identifier: BSL-1.0
 ///
 
@@ -166,6 +166,13 @@ public:
      */
     template <typename ValueType>
     ValueType convert(void) const;
+
+    /*!
+     * Templated conversion operator to assign Object to a target type.
+     * \throws ObjectConvertError if object cannot be safe casted
+     */
+    template <typename ValueType>
+    operator ValueType(void) const;
 
     /*!
      * Convert to a new Object that will be of the type specified.

--- a/include/Pothos/Object/ObjectImpl.hpp
+++ b/include/Pothos/Object/ObjectImpl.hpp
@@ -4,7 +4,7 @@
 /// Template implementation details for Object.
 ///
 /// \copyright
-/// Copyright (c) 2013-2015 Josh Blum
+/// Copyright (c) 2013-2017 Josh Blum
 /// SPDX-License-Identifier: BSL-1.0
 ///
 
@@ -228,6 +228,12 @@ ValueType Object::convert(void) const
 {
     Object newObj = this->convert(typeid(ValueType));
     return newObj.extract<ValueType>();
+}
+
+template <typename ValueType>
+Object::operator ValueType(void) const
+{
+    return this->convert<ValueType>();
 }
 
 } //namespace Pothos

--- a/include/Pothos/Proxy/Proxy.hpp
+++ b/include/Pothos/Proxy/Proxy.hpp
@@ -4,7 +4,7 @@
 /// Definitions for the Proxy wrapper class.
 ///
 /// \copyright
-/// Copyright (c) 2013-2016 Josh Blum
+/// Copyright (c) 2013-2017 Josh Blum
 /// SPDX-License-Identifier: BSL-1.0
 ///
 
@@ -70,6 +70,13 @@ public:
      */
     template <typename ValueType>
     ValueType convert(void) const;
+
+    /*!
+     * Templated conversion operator to assign Proxy to a target type.
+     * \throws ProxyEnvironmentConvertError if object cannot be converted
+     */
+    template <typename ValueType>
+    operator ValueType(void) const;
 
     //! Call a method with a return type and variable args
     template <typename ReturnType, typename... ArgsType>

--- a/include/Pothos/Proxy/ProxyImpl.hpp
+++ b/include/Pothos/Proxy/ProxyImpl.hpp
@@ -4,7 +4,7 @@
 /// Proxy template method implementations.
 ///
 /// \copyright
-/// Copyright (c) 2013-2016 Josh Blum
+/// Copyright (c) 2013-2017 Josh Blum
 /// SPDX-License-Identifier: BSL-1.0
 ///
 
@@ -66,6 +66,12 @@ makeProxy(const ProxyEnvironment::Sptr &, T &&value)
 }
 
 } //namespace Detail
+
+template <typename ValueType>
+Proxy::operator ValueType(void) const
+{
+    return this->convert<ValueType>();
+}
 
 template <typename ReturnType, typename... ArgsType>
 ReturnType Proxy::call(const std::string &name, ArgsType&&... args) const

--- a/include/Pothos/Testing.hpp
+++ b/include/Pothos/Testing.hpp
@@ -6,7 +6,7 @@
 /// The test macros are loosely based on the Boost unit test suite.
 ///
 /// \copyright
-/// Copyright (c) 2013-2015 Josh Blum
+/// Copyright (c) 2013-2017 Josh Blum
 /// SPDX-License-Identifier: BSL-1.0
 ///
 

--- a/lib/Callable/Tests.cpp
+++ b/lib/Callable/Tests.cpp
@@ -130,12 +130,12 @@ POTHOS_TEST_BLOCK("/callable/tests", test_callable_with_methods)
     POTHOS_TEST_EQUAL(getBar.getNumArgs(), 1);
     POTHOS_TEST_TRUE(getBar.type(-1) == typeid(int));
     POTHOS_TEST_TRUE(getBar.type(0) == typeid(TestClass));
-    POTHOS_TEST_THROWS(getBar.call(), Pothos::CallableArgumentError);
+    POTHOS_TEST_THROWS(getBar.call<int>(), Pothos::CallableArgumentError);
 
     //call the class methods
     TestClass test;
     setBar.call(std::ref(test), int(42));
-    POTHOS_TEST_EQUAL(42, getBar.call(std::ref(test)));
+    POTHOS_TEST_EQUAL(42, getBar.call<int>(std::ref(test)));
 
     //check the return error conditions
     POTHOS_TEST_THROWS(setBar.call<int>(std::ref(test), 21), Pothos::CallableReturnError);
@@ -152,19 +152,19 @@ POTHOS_TEST_BLOCK("/callable/tests", test_callable_with_functions)
     POTHOS_TEST_EQUAL(strLen.getNumArgs(), 1);
     POTHOS_TEST_TRUE(strLen.type(-1) == typeid(long));
     POTHOS_TEST_TRUE(strLen.type(0) == typeid(std::string));
-    POTHOS_TEST_EQUAL(5, strLen.call(std::string("hello")));
-    POTHOS_TEST_THROWS(strLen.call(NonsenseClass()), Pothos::CallableArgumentError);
+    POTHOS_TEST_EQUAL(5, strLen.call<long>(std::string("hello")));
+    POTHOS_TEST_THROWS(strLen.call<long>(NonsenseClass()), Pothos::CallableArgumentError);
 
     //test copy ability
     Pothos::Callable strLenCopy0 = strLen;
-    POTHOS_TEST_EQUAL(5, strLenCopy0.call(std::string("world")));
+    POTHOS_TEST_EQUAL(5, strLenCopy0.call<long>(std::string("world")));
 
     Pothos::Callable strLenCopy1 = Pothos::Callable(strLen);
-    POTHOS_TEST_EQUAL(2, strLenCopy1.call(std::string("!!")));
+    POTHOS_TEST_EQUAL(2, strLenCopy1.call<long>(std::string("!!")));
 
     //test multiple args
     Pothos::Callable add(&TestClass::add);
-    POTHOS_TEST_EQUAL(32, add.call(int(10), unsigned(22)));
+    POTHOS_TEST_EQUAL(32, add.call<long>(int(10), unsigned(22)));
     std::cout << add.toString() << std::endl;
 }
 
@@ -208,8 +208,8 @@ POTHOS_TEST_BLOCK("/callable/tests", test_callable_overloaded)
     POTHOS_TEST_TRUE(overloaded2.type(-1) == typeid(void));
 
     TestClass test;
-    POTHOS_TEST_EQUAL(overloaded0.call(std::ref(test), int(0)), 0);
-    POTHOS_TEST_EQUAL(overloaded1.call(std::ref(test), long(0)), 1);
+    POTHOS_TEST_EQUAL(overloaded0.call<int>(std::ref(test), int(0)), 0);
+    POTHOS_TEST_EQUAL(overloaded1.call<int>(std::ref(test), long(0)), 1);
 }
 
 /***********************************************************************
@@ -229,11 +229,11 @@ POTHOS_TEST_BLOCK("/callable/tests", test_callable_bind)
     //bind and unbind arguments for add
     Pothos::Callable add(&TestClass::add);
     add.bind(unsigned(11), 1);
-    POTHOS_TEST_EQUAL(21, add.call(int(10)));
+    POTHOS_TEST_EQUAL(21, add.call<long>(int(10)));
     add.bind(int(33), 0);
-    POTHOS_TEST_EQUAL(44, add.call());
+    POTHOS_TEST_EQUAL(44, add.call<long>());
     add.unbind(1);
-    POTHOS_TEST_EQUAL(43, add.call(unsigned(10)));
+    POTHOS_TEST_EQUAL(43, add.call<long>(unsigned(10)));
 
     //test type() and numArgs() logic with many args
     Pothos::Callable addMany(&TestClass::addMany);

--- a/lib/Callable/Tests.cpp
+++ b/lib/Callable/Tests.cpp
@@ -130,12 +130,12 @@ POTHOS_TEST_BLOCK("/callable/tests", test_callable_with_methods)
     POTHOS_TEST_EQUAL(getBar.getNumArgs(), 1);
     POTHOS_TEST_TRUE(getBar.type(-1) == typeid(int));
     POTHOS_TEST_TRUE(getBar.type(0) == typeid(TestClass));
-    POTHOS_TEST_THROWS(getBar.call<int>(), Pothos::CallableArgumentError);
+    POTHOS_TEST_THROWS(getBar.call(), Pothos::CallableArgumentError);
 
     //call the class methods
     TestClass test;
     setBar.call(std::ref(test), int(42));
-    POTHOS_TEST_EQUAL(42, getBar.call<int>(std::ref(test)));
+    POTHOS_TEST_EQUAL(42, getBar.call(std::ref(test)));
 
     //check the return error conditions
     POTHOS_TEST_THROWS(setBar.call<int>(std::ref(test), 21), Pothos::CallableReturnError);
@@ -152,19 +152,19 @@ POTHOS_TEST_BLOCK("/callable/tests", test_callable_with_functions)
     POTHOS_TEST_EQUAL(strLen.getNumArgs(), 1);
     POTHOS_TEST_TRUE(strLen.type(-1) == typeid(long));
     POTHOS_TEST_TRUE(strLen.type(0) == typeid(std::string));
-    POTHOS_TEST_EQUAL(5, strLen.call<long>(std::string("hello")));
-    POTHOS_TEST_THROWS(strLen.call<long>(NonsenseClass()), Pothos::CallableArgumentError);
+    POTHOS_TEST_EQUAL(5, strLen.call(std::string("hello")));
+    POTHOS_TEST_THROWS(strLen.call(NonsenseClass()), Pothos::CallableArgumentError);
 
     //test copy ability
     Pothos::Callable strLenCopy0 = strLen;
-    POTHOS_TEST_EQUAL(5, strLenCopy0.call<long>(std::string("world")));
+    POTHOS_TEST_EQUAL(5, strLenCopy0.call(std::string("world")));
 
     Pothos::Callable strLenCopy1 = Pothos::Callable(strLen);
-    POTHOS_TEST_EQUAL(2, strLenCopy1.call<long>(std::string("!!")));
+    POTHOS_TEST_EQUAL(2, strLenCopy1.call(std::string("!!")));
 
     //test multiple args
     Pothos::Callable add(&TestClass::add);
-    POTHOS_TEST_EQUAL(32, add.call<long>(int(10), unsigned(22)));
+    POTHOS_TEST_EQUAL(32, add.call(int(10), unsigned(22)));
     std::cout << add.toString() << std::endl;
 }
 
@@ -208,8 +208,8 @@ POTHOS_TEST_BLOCK("/callable/tests", test_callable_overloaded)
     POTHOS_TEST_TRUE(overloaded2.type(-1) == typeid(void));
 
     TestClass test;
-    POTHOS_TEST_EQUAL(overloaded0.call<int>(std::ref(test), int(0)), 0);
-    POTHOS_TEST_EQUAL(overloaded1.call<int>(std::ref(test), long(0)), 1);
+    POTHOS_TEST_EQUAL(overloaded0.call(std::ref(test), int(0)), 0);
+    POTHOS_TEST_EQUAL(overloaded1.call(std::ref(test), long(0)), 1);
 }
 
 /***********************************************************************
@@ -229,11 +229,11 @@ POTHOS_TEST_BLOCK("/callable/tests", test_callable_bind)
     //bind and unbind arguments for add
     Pothos::Callable add(&TestClass::add);
     add.bind(unsigned(11), 1);
-    POTHOS_TEST_EQUAL(21, add.call<long>(int(10)));
+    POTHOS_TEST_EQUAL(21, add.call(int(10)));
     add.bind(int(33), 0);
-    POTHOS_TEST_EQUAL(44, add.call<long>());
+    POTHOS_TEST_EQUAL(44, add.call());
     add.unbind(1);
-    POTHOS_TEST_EQUAL(43, add.call<long>(unsigned(10)));
+    POTHOS_TEST_EQUAL(43, add.call(unsigned(10)));
 
     //test type() and numArgs() logic with many args
     Pothos::Callable addMany(&TestClass::addMany);

--- a/lib/ConfLoader/ConfLoader.cpp
+++ b/lib/ConfLoader/ConfLoader.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2016 Josh Blum
+// Copyright (c) 2016-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/System.hpp>
@@ -62,7 +62,7 @@ static std::vector<Pothos::PluginPath> loadConfFile(const std::string &path)
         //call the loader
         const auto plugin = Pothos::PluginRegistry::get(loaderPath);
         const auto &loaderFcn = plugin.getObject().extract<Pothos::Callable>();
-        return loaderFcn.call<std::vector<Pothos::PluginPath>>(configMap);
+        return loaderFcn.call(configMap);
     }
     POTHOS_EXCEPTION_CATCH (const Pothos::Exception &ex)
     {

--- a/lib/Framework/BufferManager.cpp
+++ b/lib/Framework/BufferManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2014 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Framework/BufferManager.hpp>
@@ -28,7 +28,7 @@ Pothos::BufferManager::Sptr Pothos::BufferManager::make(const std::string &name)
     {
         auto plugin = Pothos::PluginRegistry::get(Pothos::PluginPath("/framework/buffer_manager").join(name));
         auto callable = plugin.getObject().extract<Pothos::Callable>();
-        manager = callable.call<Sptr>();
+        manager = callable.call();
     }
     catch(const Exception &ex)
     {

--- a/lib/Framework/Connectable.cpp
+++ b/lib/Framework/Connectable.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2015 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Framework/Connectable.hpp>
@@ -45,7 +45,7 @@ Pothos::Object Pothos::Connectable::opaqueCall(const Object *inputArgs, const si
     {
         throw Pothos::BlockCallNotFound("Pothos::Connectable::call()", "missing method name");
     }
-    return this->opaqueCallMethod(inputArgs[0].convert<std::string>(), inputArgs+1, numArgs-1);
+    return this->opaqueCallMethod(inputArgs[0], inputArgs+1, numArgs-1);
 }
 
 #include <Pothos/Managed.hpp>

--- a/lib/Framework/Topology.cpp
+++ b/lib/Framework/Topology.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "Framework/TopologyImpl.hpp"
@@ -113,20 +113,20 @@ void Pothos::Topology::_connect(
     flow.dst = _impl->makePort(dst, dstName);
 
     //perform auto-allocation, on a block this may or may not allocate, on a topology this throws
-    try{getConnectable(src).get("_actor").call<std::string>("autoAllocateOutput", srcName);}catch(const Exception &){}
-    try{getConnectable(dst).get("_actor").call<std::string>("autoAllocateInput", dstName);}catch(const Exception &){}
+    try{getConnectable(src).get("_actor").call("autoAllocateOutput", srcName);}catch(const Exception &){}
+    try{getConnectable(dst).get("_actor").call("autoAllocateInput", dstName);}catch(const Exception &){}
 
     //validate that the ports exists before connection
     if (flow.src.obj)
     {
-        auto outs = getConnectable(src).call<std::vector<std::string>>("outputPortNames");
+        std::vector<std::string> outs = getConnectable(src).call("outputPortNames");
         if (std::find(outs.begin(), outs.end(), srcName) == outs.end())
             throw Pothos::TopologyConnectError("Pothos::Topology::connect()", flow.src.toString() + " has no output port named " + srcName);
     }
 
     if (flow.dst.obj)
     {
-        auto ins = getConnectable(dst).call<std::vector<std::string>>("inputPortNames");
+        std::vector<std::string> ins = getConnectable(dst).call("inputPortNames");
         if (std::find(ins.begin(), ins.end(), dstName) == ins.end())
             throw Pothos::TopologyConnectError("Pothos::Topology::connect()", flow.dst.toString() + " has no input port named " + dstName);
     }
@@ -186,11 +186,11 @@ void Pothos::Topology::_disconnect(
     flow.dst = _impl->makePort(dst, dstName);
 
     //validate that the ports exists before disconnection
-    auto outs = getConnectable(src).call<std::vector<std::string>>("outputPortNames");
+    std::vector<std::string> outs = getConnectable(src).call("outputPortNames");
     if (std::find(outs.begin(), outs.end(), srcName) == outs.end())
         throw Pothos::TopologyConnectError("Pothos::Topology::disconnect()", flow.src.toString() + " has no output port named " + srcName);
 
-    auto ins = getConnectable(dst).call<std::vector<std::string>>("inputPortNames");
+    std::vector<std::string> ins = getConnectable(dst).call("inputPortNames");
     if (std::find(ins.begin(), ins.end(), dstName) == ins.end())
         throw Pothos::TopologyConnectError("Pothos::Topology::disconnect()", flow.dst.toString() + " has no input port named " + dstName);
 
@@ -203,8 +203,8 @@ void Pothos::Topology::_disconnect(
         Poco::format("this flow does not exist in the topology(%s)", flow.toString()));
 
     //perform auto-deletion, on a block this may or may not delete, on a topology this throws
-    try{getConnectable(src).get("_actor").call<std::string>("autoDeleteOutput", srcName);}catch(const Exception &){}
-    try{getConnectable(dst).get("_actor").call<std::string>("autoDeleteInput", dstName);}catch(const Exception &){}
+    try{getConnectable(src).get("_actor").call("autoDeleteOutput", srcName);}catch(const Exception &){}
+    try{getConnectable(dst).get("_actor").call("autoDeleteInput", dstName);}catch(const Exception &){}
 
     _impl->flows.erase(it);
 }
@@ -231,8 +231,8 @@ void Pothos::Topology::disconnectAll(const bool recursive)
     //perform auto-deletion, on a block this may or may not delete, on a topology this throws
     for (const auto &flow : _impl->flows)
     {
-        if (flow.src.obj) try{getInternalBlock(flow.src.obj).get("_actor").call<std::string>("autoDeleteOutput", flow.src.name);}catch(const Exception &){}
-        if (flow.dst.obj) try{getInternalBlock(flow.dst.obj).get("_actor").call<std::string>("autoDeleteInput", flow.dst.name);}catch(const Exception &){}
+        if (flow.src.obj) try{getInternalBlock(flow.src.obj).get("_actor").call("autoDeleteOutput", flow.src.name);}catch(const Exception &){}
+        if (flow.dst.obj) try{getInternalBlock(flow.dst.obj).get("_actor").call("autoDeleteInput", flow.dst.name);}catch(const Exception &){}
     }
 
     //clear our own local flows
@@ -262,7 +262,7 @@ bool Pothos::Topology::waitInactive(const double idleDuration, const double time
         for (size_t i = 0; i < blocks.size(); i++)
         {
             const auto &block = blocks[i];
-            const auto activityIndicator = block.get("_actor").call<int>("queryActivityIndicator");
+            const int activityIndicator = block.get("_actor").call("queryActivityIndicator");
             if (lastActivityIndicator[i] != activityIndicator)
             {
                 lastActivityTime[i] = std::chrono::high_resolution_clock::now();

--- a/lib/Framework/TopologyCommit.cpp
+++ b/lib/Framework/TopologyCommit.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "Framework/TopologyImpl.hpp"
@@ -40,7 +40,7 @@ std::string collectFutureInfoErrors(const std::vector<FutureInfo> infoFutures)
 static std::string getBufferMode(const Port &port, const std::string &domain, const bool &isInput)
 {
     auto actor = port.obj.get("_actor");
-    return actor.call<std::string>("getBufferMode", port.name, domain, isInput);
+    return actor.call("getBufferMode", port.name, domain, isInput);
 }
 
 static Pothos::Proxy getBufferManager(const Port &port, const std::string &domain, const bool &isInput)
@@ -77,8 +77,8 @@ static void installBufferManagers(const std::vector<Flow> &flatFlows)
         auto dst = dsts.at(0);
         Pothos::Proxy manager;
 
-        auto srcDomain = src.obj.call("output", src.name).call<std::string>("domain");
-        auto dstDomain = dst.obj.call("input", dst.name).call<std::string>("domain");
+        std::string srcDomain = src.obj.call("output", src.name).call("domain");
+        std::string dstDomain = dst.obj.call("input", dst.name).call("domain");
 
         auto srcMode = getBufferMode(src, dstDomain, false);
         auto dstMode = getBufferMode(dst, srcDomain, true);
@@ -95,7 +95,7 @@ static void installBufferManagers(const std::vector<Flow> &flatFlows)
             for (const auto &otherDst : dsts)
             {
                 if (otherDst == dst) continue;
-                auto otherDstDomain = otherDst.obj.call("input", otherDst.name).call<std::string>("domain");
+                std::string otherDstDomain = otherDst.obj.call("input", otherDst.name).call("domain");
                 if (getBufferMode(otherDst, srcDomain, true) != "ABDICATE" and not otherDstDomain.empty())
                 {
                     throw Pothos::Exception("Pothos::Topology::installBufferManagers", Poco::format("%s->%s\n"

--- a/lib/Framework/TopologyDomainFlows.cpp
+++ b/lib/Framework/TopologyDomainFlows.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "Framework/TopologyImpl.hpp"
@@ -13,12 +13,12 @@
 static std::string getBufferMode(const Port &port, const std::string &domain, const bool &isInput)
 {
     auto actor = port.obj.get("_actor");
-    return actor.call<std::string>("getBufferMode", port.name, domain, isInput);
+    return actor.call("getBufferMode", port.name, domain, isInput);
 }
 
 static std::string getDomain(const Port &port, const bool &isInput)
 {
-    return port.obj.call(isInput?"input":"output", port.name).call<std::string>("domain");
+    return port.obj.call(isInput?"input":"output", port.name).call("domain");
 }
 
 /***********************************************************************

--- a/lib/Framework/TopologyDumpJSON.cpp
+++ b/lib/Framework/TopologyDumpJSON.cpp
@@ -188,7 +188,7 @@ std::string Pothos::Topology::dumpJSON(const std::string &request)
     for (const auto &block : getObjSetFromFlowList(flows))
     {
         //gather block info
-        const auto blockId = block.call<std::string>("uid");
+        const std::string blockId = block.call("uid");
         auto &blockObj = blocksObj[blockId];
 
         //replace rendered names with names from flattened hierarchy
@@ -217,7 +217,7 @@ std::string Pothos::Topology::dumpJSON(const std::string &request)
         //sub-topology info
         if (traverse and this->uid() != blockId) try
         {
-            auto subDump = block.call<std::string>("dumpJSON", "{\"mode\":\"top\"}");
+            std::string subDump = block.call("dumpJSON", "{\"mode\":\"top\"}");
             auto subObj = json::parse(subDump);
             for (auto it = subObj.begin(); it != subObj.end(); ++it)
             {

--- a/lib/Framework/TopologyImpl.hpp
+++ b/lib/Framework/TopologyImpl.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2015 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
@@ -114,7 +114,7 @@ inline bool checkObj(const Pothos::Object &o)
 {
     try
     {
-        getProxy(o).call<std::string>("uid");
+        getProxy(o).call("uid");
     }
     catch(...)
     {

--- a/lib/Framework/TopologyMakeJSON.cpp
+++ b/lib/Framework/TopologyMakeJSON.cpp
@@ -45,7 +45,7 @@ static std::vector<Pothos::Proxy> evalArgsArray(
     {
         args.push_back(evalExpression(evaluator, argsArray.at(i)));
     }
-    return Pothos::Object(args).convert<std::vector<Pothos::Proxy>>();
+    return Pothos::Object(args);
 }
 
 typedef std::vector<std::pair<std::string, json>> OrderedVarMap;

--- a/lib/Framework/TopologyNetworkFlows.cpp
+++ b/lib/Framework/TopologyNetworkFlows.cpp
@@ -39,7 +39,7 @@ std::pair<Pothos::Proxy, Pothos::Proxy> createNetworkFlow(const Flow &flow)
     uri.setScheme("tcp");
     uri.setHost(bindIp);
     netBind = bindEnv->findProxy("Pothos/BlockRegistry").call(netBindPath, uri.toString(), "BIND");
-    auto connectPort = netBind.call<std::string>("getActualPort");
+    const std::string connectPort = netBind.call("getActualPort");
     uri.setPort(std::stoi(connectPort));
     netConn = connEnv->findProxy("Pothos/BlockRegistry").call(netConnPath, uri.toString(), "CONNECT");
 

--- a/lib/Framework/TopologySquashFlows.cpp
+++ b/lib/Framework/TopologySquashFlows.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "Framework/TopologyImpl.hpp"
@@ -58,7 +58,7 @@ static std::vector<Port> resolvePorts(const Port &port, const bool isSource)
         return ports;
     }
 
-    const auto len = subPorts.call<size_t>("size");
+    const size_t len = subPorts.call("size");
     for (size_t i = 0; i < len; i++)
     {
         ports.push_back(proxyToPort(subPorts.call("at", i)));
@@ -98,7 +98,7 @@ static std::vector<Flow> resolveFlows(const Pothos::Proxy &obj)
         return flows;
     }
 
-    const auto len = subFlows.call<size_t>("size");
+    const size_t len = subFlows.call("size");
     for (size_t i = 0; i < len; i++)
     {
         flows.push_back(proxyToFlow(subFlows.call("at", i)));

--- a/lib/Framework/WorkerActor.hpp
+++ b/lib/Framework/WorkerActor.hpp
@@ -65,6 +65,7 @@ public:
     Block *block;
     bool activeState;
     std::atomic<int> activityIndicator;
+    std::set<std::string> automaticSlots;
     std::map<std::string, std::unique_ptr<InputPort>> inputs;
     std::map<std::string, std::unique_ptr<OutputPort>> outputs;
     std::map<bool, std::map<std::string, std::map<std::string, std::string>>> bufferModeCache;

--- a/lib/Managed/Builtin/TestManaged.cpp
+++ b/lib/Managed/Builtin/TestManaged.cpp
@@ -59,5 +59,5 @@ POTHOS_TEST_BLOCK("/proxy/managed/tests", test_containers)
     POTHOS_TEST_EQUAL(findHi->second.convert<std::string>(), "bye");
     auto find1 = resultDict.find(env->makeProxy(1));
     POTHOS_TEST_TRUE(find1 != resultDict.end());
-    POTHOS_TEST_EQUAL(find1->second, 2);
+    POTHOS_TEST_EQUAL(find1->second.convert<int>(), 2);
 }

--- a/lib/Managed/Builtin/TestManaged.cpp
+++ b/lib/Managed/Builtin/TestManaged.cpp
@@ -25,9 +25,9 @@ POTHOS_TEST_BLOCK("/proxy/managed/tests", test_containers)
 
     //check for equality
     POTHOS_TEST_EQUAL(testVec.size(), resultVec.size());
-    POTHOS_TEST_EQUAL(testVec[0].convert<std::string>(), resultVec[0].convert<std::string>());
-    POTHOS_TEST_EQUAL(testVec[1].convert<int>(), resultVec[1].convert<int>());
-    POTHOS_TEST_EQUAL(testVec[2].convert<std::complex<double>>(), resultVec[2].convert<std::complex<double>>());
+    POTHOS_TEST_EQUAL((const std::string &)testVec[0], (const std::string &)resultVec[0]);
+    POTHOS_TEST_EQUAL(int(testVec[1]), int(resultVec[1]));
+    POTHOS_TEST_EQUAL((const std::complex<double> &)testVec[2], (const std::complex<double> &)resultVec[2]);
 
     //make test set
     Pothos::ProxySet testSet;
@@ -56,8 +56,8 @@ POTHOS_TEST_BLOCK("/proxy/managed/tests", test_containers)
     //check result
     auto findHi = resultDict.find(env->makeProxy("hi"));
     POTHOS_TEST_TRUE(findHi != resultDict.end());
-    POTHOS_TEST_EQUAL(findHi->second.convert<std::string>(), "bye");
+    POTHOS_TEST_EQUAL((const std::string &)findHi->second, "bye");
     auto find1 = resultDict.find(env->makeProxy(1));
     POTHOS_TEST_TRUE(find1 != resultDict.end());
-    POTHOS_TEST_EQUAL(find1->second.convert<int>(), 2);
+    POTHOS_TEST_EQUAL(int(find1->second), 2);
 }

--- a/lib/Managed/Builtin/TestManaged.cpp
+++ b/lib/Managed/Builtin/TestManaged.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2014 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Testing.hpp>
@@ -21,7 +21,7 @@ POTHOS_TEST_BLOCK("/proxy/managed/tests", test_containers)
 
     //convert to proxy and back
     auto proxyVec = env->makeProxy(testVec);
-    auto resultVec = proxyVec.convert<Pothos::ProxyVector>();
+    Pothos::ProxyVector resultVec = proxyVec;
 
     //check for equality
     POTHOS_TEST_EQUAL(testVec.size(), resultVec.size());
@@ -36,7 +36,7 @@ POTHOS_TEST_BLOCK("/proxy/managed/tests", test_containers)
 
     //convert to proxy and back
     auto proxySet = env->makeProxy(testSet);
-    auto resultSet = proxySet.convert<Pothos::ProxySet>();
+    Pothos::ProxySet resultSet = proxySet;
 
     //check result
     auto findHiSet = resultSet.find(env->makeProxy("hi"));
@@ -51,7 +51,7 @@ POTHOS_TEST_BLOCK("/proxy/managed/tests", test_containers)
 
     //convert to proxy and back
     auto proxyDict = env->makeProxy(testDict);
-    auto resultDict = proxyDict.convert<Pothos::ProxyMap>();
+    Pothos::ProxyMap resultDict = proxyDict;
 
     //check result
     auto findHi = resultDict.find(env->makeProxy("hi"));

--- a/lib/Managed/Builtin/TestManaged.cpp
+++ b/lib/Managed/Builtin/TestManaged.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2017 Josh Blum
+// Copyright (c) 2013-2014 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Testing.hpp>
@@ -25,9 +25,9 @@ POTHOS_TEST_BLOCK("/proxy/managed/tests", test_containers)
 
     //check for equality
     POTHOS_TEST_EQUAL(testVec.size(), resultVec.size());
-    POTHOS_TEST_EQUAL((const std::string &)testVec[0], (const std::string &)resultVec[0]);
-    POTHOS_TEST_EQUAL(int(testVec[1]), int(resultVec[1]));
-    POTHOS_TEST_EQUAL((const std::complex<double> &)testVec[2], (const std::complex<double> &)resultVec[2]);
+    POTHOS_TEST_EQUAL(testVec[0].convert<std::string>(), resultVec[0].convert<std::string>());
+    POTHOS_TEST_EQUAL(testVec[1].convert<int>(), resultVec[1].convert<int>());
+    POTHOS_TEST_EQUAL(testVec[2].convert<std::complex<double>>(), resultVec[2].convert<std::complex<double>>());
 
     //make test set
     Pothos::ProxySet testSet;
@@ -56,8 +56,8 @@ POTHOS_TEST_BLOCK("/proxy/managed/tests", test_containers)
     //check result
     auto findHi = resultDict.find(env->makeProxy("hi"));
     POTHOS_TEST_TRUE(findHi != resultDict.end());
-    POTHOS_TEST_EQUAL((const std::string &)findHi->second, "bye");
+    POTHOS_TEST_EQUAL(findHi->second.convert<std::string>(), "bye");
     auto find1 = resultDict.find(env->makeProxy(1));
     POTHOS_TEST_TRUE(find1 != resultDict.end());
-    POTHOS_TEST_EQUAL(int(find1->second), 2);
+    POTHOS_TEST_EQUAL(find1->second, 2);
 }

--- a/lib/Managed/Builtin/TestManagedInheritance.cpp
+++ b/lib/Managed/Builtin/TestManagedInheritance.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2016 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Testing.hpp>
@@ -44,7 +44,7 @@ static void test_inheritance0(Pothos::ProxyEnvironment::Sptr env)
 
     //prove that base class can work
     auto myBase0 = env->findProxy("MyBaseClass0")();
-    POTHOS_TEST_EQUAL(-42, myBase0.call<int>("negateInt", 42));
+    POTHOS_TEST_EQUAL(-42, myBase0.call("negateInt", 42));
 
     Pothos::ManagedClass()
         .registerConstructor<MyDerivedClass0>()
@@ -53,7 +53,7 @@ static void test_inheritance0(Pothos::ProxyEnvironment::Sptr env)
 
     //prove that derived class has the base methods
     auto myDerived0 = env->findProxy("MyDerivedClass0")();
-    POTHOS_TEST_EQUAL(-42, myDerived0.call<int>("negateInt", 42));
+    POTHOS_TEST_EQUAL(-42, myDerived0.call("negateInt", 42));
 
     //runtime registration does not associate the module
     //therefore to be safe, we unregister these classes now

--- a/lib/Managed/Builtin/TestManagedInheritance.cpp
+++ b/lib/Managed/Builtin/TestManagedInheritance.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2017 Josh Blum
+// Copyright (c) 2013-2016 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Testing.hpp>
@@ -44,7 +44,7 @@ static void test_inheritance0(Pothos::ProxyEnvironment::Sptr env)
 
     //prove that base class can work
     auto myBase0 = env->findProxy("MyBaseClass0")();
-    POTHOS_TEST_EQUAL(-42, myBase0.call("negateInt", 42));
+    POTHOS_TEST_EQUAL(-42, int(myBase0.call("negateInt", 42)));
 
     Pothos::ManagedClass()
         .registerConstructor<MyDerivedClass0>()
@@ -53,7 +53,7 @@ static void test_inheritance0(Pothos::ProxyEnvironment::Sptr env)
 
     //prove that derived class has the base methods
     auto myDerived0 = env->findProxy("MyDerivedClass0")();
-    POTHOS_TEST_EQUAL(-42, myDerived0.call("negateInt", 42));
+    POTHOS_TEST_EQUAL(-42, int(myDerived0.call("negateInt", 42)));
 
     //runtime registration does not associate the module
     //therefore to be safe, we unregister these classes now

--- a/lib/Managed/Builtin/TestManagedOpaque.cpp
+++ b/lib/Managed/Builtin/TestManagedOpaque.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017 Josh Blum
+// Copyright (c) 2014-2016 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Testing.hpp>
@@ -11,18 +11,18 @@ struct SuperOpaque
 {
     SuperOpaque(const Pothos::Object *args, const size_t numArgs)
     {
-        if (numArgs > 0) _value = args[0].operator std::string();
+        if (numArgs > 0) _value = args[0].convert<std::string>();
     }
 
     Pothos::Object foo(const Pothos::Object *args, const size_t numArgs)
     {
-        if (numArgs > 0) _value = args[0].operator std::string();
+        if (numArgs > 0) _value = args[0].convert<std::string>();
         return Pothos::Object(_value);
     }
 
     static Pothos::Object bar(const Pothos::Object *args, const size_t numArgs)
     {
-        if (numArgs > 0) return Pothos::Object(args[0].operator std::string());
+        if (numArgs > 0) return Pothos::Object(args[0].convert<std::string>());
         return Pothos::Object("");
     }
 

--- a/lib/Managed/Builtin/TestManagedOpaque.cpp
+++ b/lib/Managed/Builtin/TestManagedOpaque.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Testing.hpp>
@@ -11,18 +11,18 @@ struct SuperOpaque
 {
     SuperOpaque(const Pothos::Object *args, const size_t numArgs)
     {
-        if (numArgs > 0) _value = args[0].convert<std::string>();
+        if (numArgs > 0) _value = args[0].operator std::string();
     }
 
     Pothos::Object foo(const Pothos::Object *args, const size_t numArgs)
     {
-        if (numArgs > 0) _value = args[0].convert<std::string>();
+        if (numArgs > 0) _value = args[0].operator std::string();
         return Pothos::Object(_value);
     }
 
     static Pothos::Object bar(const Pothos::Object *args, const size_t numArgs)
     {
-        if (numArgs > 0) return Pothos::Object(args[0].convert<std::string>());
+        if (numArgs > 0) return Pothos::Object(args[0].operator std::string());
         return Pothos::Object("");
     }
 

--- a/lib/Managed/Builtin/TestManagedWildcard.cpp
+++ b/lib/Managed/Builtin/TestManagedWildcard.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017 Josh Blum
+// Copyright (c) 2014-2016 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Testing.hpp>
@@ -11,14 +11,14 @@ struct SuperWildcard
 {
     SuperWildcard(const Pothos::Object *args, const size_t numArgs)
     {
-        if (numArgs > 0) _value = args[0].operator std::string();
+        if (numArgs > 0) _value = args[0].convert<std::string>();
     }
 
     Pothos::Object foo(const std::string &name, const Pothos::Object *args, const size_t numArgs)
     {
         if (name == "foo")
         {
-            if (numArgs > 0) _value = args[0].operator std::string();
+            if (numArgs > 0) _value = args[0].convert<std::string>();
             return Pothos::Object(_value);
         }
         return Pothos::Object();
@@ -28,7 +28,7 @@ struct SuperWildcard
     {
         if (name == "bar")
         {
-            if (numArgs > 0) return Pothos::Object(args[0].operator std::string());
+            if (numArgs > 0) return Pothos::Object(args[0].convert<std::string>());
             return Pothos::Object("");
         }
         return Pothos::Object();

--- a/lib/Managed/Builtin/TestManagedWildcard.cpp
+++ b/lib/Managed/Builtin/TestManagedWildcard.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Testing.hpp>
@@ -11,14 +11,14 @@ struct SuperWildcard
 {
     SuperWildcard(const Pothos::Object *args, const size_t numArgs)
     {
-        if (numArgs > 0) _value = args[0].convert<std::string>();
+        if (numArgs > 0) _value = args[0].operator std::string();
     }
 
     Pothos::Object foo(const std::string &name, const Pothos::Object *args, const size_t numArgs)
     {
         if (name == "foo")
         {
-            if (numArgs > 0) _value = args[0].convert<std::string>();
+            if (numArgs > 0) _value = args[0].operator std::string();
             return Pothos::Object(_value);
         }
         return Pothos::Object();
@@ -28,7 +28,7 @@ struct SuperWildcard
     {
         if (name == "bar")
         {
-            if (numArgs > 0) return Pothos::Object(args[0].convert<std::string>());
+            if (numArgs > 0) return Pothos::Object(args[0].operator std::string());
             return Pothos::Object("");
         }
         return Pothos::Object();

--- a/lib/Object/Builtin/Tests.cpp
+++ b/lib/Object/Builtin/Tests.cpp
@@ -88,6 +88,17 @@ POTHOS_TEST_BLOCK("/object/tests", test_convert_numbers)
     POTHOS_TEST_TRUE(intObj.canConvert(typeid(long)));
     POTHOS_TEST_TRUE(not intObj.canConvert(typeid(NeverHeardOfFooBar)));
 
+    //tests bool explicit and implicit
+    Pothos::Object trueObj(true);
+    POTHOS_TEST_TRUE(trueObj.convert<bool>());
+    const bool trueRes = trueObj;
+    POTHOS_TEST_TRUE(trueRes);
+
+    Pothos::Object falseObj(false);
+    POTHOS_TEST_TRUE(not falseObj.convert<bool>());
+    const bool falseRes = falseObj;
+    POTHOS_TEST_TRUE(not falseRes);
+
     //test int to double
     POTHOS_TEST_EQUAL(double(Pothos::Object(+1)), +1.0);
     POTHOS_TEST_EQUAL(double(Pothos::Object(-1)), -1.0);

--- a/lib/Object/Builtin/Tests.cpp
+++ b/lib/Object/Builtin/Tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2014 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Object.hpp>
@@ -79,9 +79,9 @@ POTHOS_TEST_BLOCK("/object/tests", test_object_mutable_copy_assigns)
 POTHOS_TEST_BLOCK("/object/tests", test_convert_numbers)
 {
     Pothos::Object intObj(int(42));
-    const long longVal = intObj.convert<long>();
+    const long longVal = intObj;
     POTHOS_TEST_EQUAL(longVal, 42);
-    POTHOS_TEST_THROWS(intObj.convert<NeverHeardOfFooBar>(), Pothos::ObjectConvertError);
+    POTHOS_TEST_THROWS((const NeverHeardOfFooBar &)intObj, Pothos::ObjectConvertError);
 
     //tests for canConvert
     POTHOS_TEST_TRUE(intObj.canConvert(typeid(int)));
@@ -89,21 +89,21 @@ POTHOS_TEST_BLOCK("/object/tests", test_convert_numbers)
     POTHOS_TEST_TRUE(not intObj.canConvert(typeid(NeverHeardOfFooBar)));
 
     //test int to double
-    POTHOS_TEST_EQUAL(Pothos::Object(+1).convert<double>(), +1.0);
-    POTHOS_TEST_EQUAL(Pothos::Object(-1).convert<double>(), -1.0);
-    POTHOS_TEST_EQUAL(Pothos::Object(0).convert<double>(), 0.0);
+    POTHOS_TEST_EQUAL(double(Pothos::Object(+1)), +1.0);
+    POTHOS_TEST_EQUAL(double(Pothos::Object(-1)), -1.0);
+    POTHOS_TEST_EQUAL(double(Pothos::Object(0)), 0.0);
 
     //tests for range errors
-    POTHOS_TEST_THROWS(Pothos::Object(-1).convert<unsigned>(), Pothos::RangeException);
-    POTHOS_TEST_THROWS(Pothos::Object(1024).convert<char>(), Pothos::RangeException);
-    POTHOS_TEST_THROWS(Pothos::Object(-1024).convert<char>(), Pothos::RangeException);
+    POTHOS_TEST_THROWS(unsigned(Pothos::Object(-1)), Pothos::RangeException);
+    POTHOS_TEST_THROWS(char(Pothos::Object(1024)), Pothos::RangeException);
+    POTHOS_TEST_THROWS(char(Pothos::Object(-1024)), Pothos::RangeException);
 }
 
 POTHOS_TEST_BLOCK("/object/tests", test_convert_complex)
 {
     Pothos::Object complexObj(std::complex<double>(2, -3));
-    POTHOS_TEST_EQUAL(complexObj.convert<std::complex<float>>(), std::complex<float>(2, -3));
-    POTHOS_TEST_THROWS(complexObj.convert<int>(), Pothos::RangeException);
+    POTHOS_TEST_EQUAL((const std::complex<float> &)complexObj, std::complex<float>(2, -3));
+    POTHOS_TEST_THROWS((int)complexObj, Pothos::RangeException);
 }
 
 POTHOS_TEST_BLOCK("/object/tests", test_convert_vectors)
@@ -114,7 +114,7 @@ POTHOS_TEST_BLOCK("/object/tests", test_convert_vectors)
     inputVec.push_back(3);
     Pothos::Object inputVecObj(inputVec);
 
-    auto outputVec = inputVecObj.convert<std::vector<unsigned long>>();
+    std::vector<unsigned long> outputVec = inputVecObj;
 
     POTHOS_TEST_EQUALV(inputVec, outputVec);
 }

--- a/lib/Object/Builtin/Tests.cpp
+++ b/lib/Object/Builtin/Tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2014 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Object.hpp>
@@ -89,9 +89,9 @@ POTHOS_TEST_BLOCK("/object/tests", test_convert_numbers)
     POTHOS_TEST_TRUE(not intObj.canConvert(typeid(NeverHeardOfFooBar)));
 
     //test int to double
-    POTHOS_TEST_EQUAL(Pothos::Object(+1), +1.0);
-    POTHOS_TEST_EQUAL(Pothos::Object(-1), -1.0);
-    POTHOS_TEST_EQUAL(Pothos::Object(0), 0.0);
+    POTHOS_TEST_EQUAL(double(Pothos::Object(+1)), +1.0);
+    POTHOS_TEST_EQUAL(double(Pothos::Object(-1)), -1.0);
+    POTHOS_TEST_EQUAL(double(Pothos::Object(0)), 0.0);
 
     //tests for range errors
     POTHOS_TEST_THROWS(Pothos::Object(-1).convert<unsigned>(), Pothos::RangeException);

--- a/lib/Object/Builtin/Tests.cpp
+++ b/lib/Object/Builtin/Tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2017 Josh Blum
+// Copyright (c) 2013-2014 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Object.hpp>
@@ -81,7 +81,7 @@ POTHOS_TEST_BLOCK("/object/tests", test_convert_numbers)
     Pothos::Object intObj(int(42));
     const long longVal = intObj;
     POTHOS_TEST_EQUAL(longVal, 42);
-    POTHOS_TEST_THROWS((const NeverHeardOfFooBar &)intObj, Pothos::ObjectConvertError);
+    POTHOS_TEST_THROWS(intObj.convert<NeverHeardOfFooBar>(), Pothos::ObjectConvertError);
 
     //tests for canConvert
     POTHOS_TEST_TRUE(intObj.canConvert(typeid(int)));
@@ -89,21 +89,21 @@ POTHOS_TEST_BLOCK("/object/tests", test_convert_numbers)
     POTHOS_TEST_TRUE(not intObj.canConvert(typeid(NeverHeardOfFooBar)));
 
     //test int to double
-    POTHOS_TEST_EQUAL(double(Pothos::Object(+1)), +1.0);
-    POTHOS_TEST_EQUAL(double(Pothos::Object(-1)), -1.0);
-    POTHOS_TEST_EQUAL(double(Pothos::Object(0)), 0.0);
+    POTHOS_TEST_EQUAL(Pothos::Object(+1), +1.0);
+    POTHOS_TEST_EQUAL(Pothos::Object(-1), -1.0);
+    POTHOS_TEST_EQUAL(Pothos::Object(0), 0.0);
 
     //tests for range errors
-    POTHOS_TEST_THROWS(unsigned(Pothos::Object(-1)), Pothos::RangeException);
-    POTHOS_TEST_THROWS(char(Pothos::Object(1024)), Pothos::RangeException);
-    POTHOS_TEST_THROWS(char(Pothos::Object(-1024)), Pothos::RangeException);
+    POTHOS_TEST_THROWS(Pothos::Object(-1).convert<unsigned>(), Pothos::RangeException);
+    POTHOS_TEST_THROWS(Pothos::Object(1024).convert<char>(), Pothos::RangeException);
+    POTHOS_TEST_THROWS(Pothos::Object(-1024).convert<char>(), Pothos::RangeException);
 }
 
 POTHOS_TEST_BLOCK("/object/tests", test_convert_complex)
 {
     Pothos::Object complexObj(std::complex<double>(2, -3));
-    POTHOS_TEST_EQUAL((const std::complex<float> &)complexObj, std::complex<float>(2, -3));
-    POTHOS_TEST_THROWS((int)complexObj, Pothos::RangeException);
+    POTHOS_TEST_EQUAL(complexObj.convert<std::complex<float>>(), std::complex<float>(2, -3));
+    POTHOS_TEST_THROWS(complexObj.convert<int>(), Pothos::RangeException);
 }
 
 POTHOS_TEST_BLOCK("/object/tests", test_convert_vectors)

--- a/lib/Object/Compare.cpp
+++ b/lib/Object/Compare.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2016 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Object/Object.hpp>
@@ -91,7 +91,7 @@ int Pothos::Object::compareTo(const Pothos::Object &other) const
     //try a number type just in the case that this is possible
     if (it == getCompareMap().end()) try
     {
-        return Pothos::Util::compareTo(this->convert<double>(), other.convert<double>());
+        return Pothos::Util::compareTo(double(*this), double(other));
     }
     catch(const Pothos::ObjectConvertError &){}
 

--- a/lib/Object/ToString.cpp
+++ b/lib/Object/ToString.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2015 Josh Blum
+// Copyright (c) 2015-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Object/ObjectImpl.hpp>
@@ -22,7 +22,7 @@ std::string Pothos::Object::toString(void) const
         const Pothos::DType dtype(this->type());
         if (dtype.isComplex() and dtype.isFloat())
         {
-            const auto c = this->convert<std::complex<double>>();
+            const std::complex<double> c = *this;
             if (c.imag() == 0.0) return std::to_string(c.real());
             if (c.real() == 0.0) return std::to_string(c.imag())+"j";
             if (c.imag() < 0.0) return Poco::format("%f-%fj", c.real(), -c.imag());
@@ -30,15 +30,15 @@ std::string Pothos::Object::toString(void) const
         }
         if (dtype.isComplex())
         {
-            const auto c = this->convert<std::complex<long long>>();
+            const std::complex<long long> c = *this;
             if (c.imag() == 0) return std::to_string(c.real());
             if (c.real() == 0) return std::to_string(c.imag())+"j";
             if (c.imag() < 0) return Poco::format("%s-%sj", std::to_string(c.real()), std::to_string(-c.imag()));
             return Poco::format("%s+%sj", std::to_string(c.real()), std::to_string(c.imag()));
         }
-        if (dtype.isFloat()) return std::to_string(this->convert<double>());
-        if (dtype.isSigned()) return std::to_string(this->convert<long long>());
-        return std::to_string(this->convert<unsigned long long>());
+        if (dtype.isFloat()) return std::to_string(double(*this));
+        if (dtype.isSigned()) return std::to_string((long long)(*this));
+        return std::to_string((unsigned long long)(*this));
     }
     catch (...) {}
 

--- a/lib/Object/ToString.cpp
+++ b/lib/Object/ToString.cpp
@@ -46,7 +46,7 @@ std::string Pothos::Object::toString(void) const
     if (this->canConvert(typeid(Pothos::ObjectVector))) try
     {
         std::string out = "[";
-        for (const auto &obj_i : this->convert<Pothos::ObjectVector>())
+        for (const auto &obj_i : this->operator Pothos::ObjectVector())
         {
             if (out.size() > 1) out += ", ";
             out += obj_i.toString();
@@ -59,7 +59,7 @@ std::string Pothos::Object::toString(void) const
     if (this->canConvert(typeid(Pothos::ObjectMap))) try
     {
         std::string out = "{";
-        for (const auto &pair : this->convert<Pothos::ObjectMap>())
+        for (const auto &pair : this->operator Pothos::ObjectMap())
         {
             if (out.size() > 1) out += ", ";
             out += Poco::format("%s: %s", pair.first.toString(), pair.second.toString());

--- a/lib/Object/ToString.cpp
+++ b/lib/Object/ToString.cpp
@@ -46,7 +46,7 @@ std::string Pothos::Object::toString(void) const
     if (this->canConvert(typeid(Pothos::ObjectVector))) try
     {
         std::string out = "[";
-        for (const auto &obj_i : this->operator Pothos::ObjectVector())
+        for (const auto &obj_i : this->convert<Pothos::ObjectVector>())
         {
             if (out.size() > 1) out += ", ";
             out += obj_i.toString();
@@ -59,7 +59,7 @@ std::string Pothos::Object::toString(void) const
     if (this->canConvert(typeid(Pothos::ObjectMap))) try
     {
         std::string out = "{";
-        for (const auto &pair : this->operator Pothos::ObjectMap())
+        for (const auto &pair : this->convert<Pothos::ObjectMap>())
         {
             if (out.size() > 1) out += ", ";
             out += Poco::format("%s: %s", pair.first.toString(), pair.second.toString());

--- a/lib/Proxy/Builtin/ConvertContainers.cpp
+++ b/lib/Proxy/Builtin/ConvertContainers.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Object/Containers.hpp>
@@ -14,7 +14,7 @@ std::vector<OutType> convertProxyVectorToNativeVector(const Pothos::ProxyVector 
     std::vector<OutType> nativeVec;
     for (const auto &elem : v)
     {
-        nativeVec.push_back(elem.convert<OutType>());
+        nativeVec.push_back(elem);
     }
     return nativeVec;
 }
@@ -68,7 +68,7 @@ std::map<KeyType, ValType> convertProxyMapToNativeMap(const Pothos::ProxyMap &m)
     std::map<KeyType, ValType> out;
     for (const auto &pair : m)
     {
-        out[pair.first.convert<KeyType>()] = pair.second.convert<ValType>();
+        out[pair.first] = (const ValType &)pair.second;
     }
     return out;
 }

--- a/lib/Proxy/Environment.cpp
+++ b/lib/Proxy/Environment.cpp
@@ -14,7 +14,7 @@ Pothos::ProxyEnvironment::Sptr Pothos::ProxyEnvironment::make(const std::string 
     {
         auto plugin = Pothos::PluginRegistry::get(Pothos::PluginPath("/proxy/environment").join(name));
         auto callable = plugin.getObject().extract<Pothos::Callable>();
-        environment = callable.call<Sptr>(args);
+        environment = callable.call(args);
     }
     catch(const Exception &ex)
     {

--- a/lib/Remote/Builtin/TestRemote.cpp
+++ b/lib/Remote/Builtin/TestRemote.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2016 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Testing.hpp>
@@ -86,12 +86,12 @@ static void test_simple_runner(Pothos::ProxyEnvironment::Sptr env)
     auto superBarProxy = env->findProxy("SuperBar");
 
     //test a static method
-    POTHOS_TEST_EQUAL(superBarProxy.call<int>("what"), 42);
+    POTHOS_TEST_EQUAL(superBarProxy.call("what"), 42);
 
     //make an instance and test
     auto superBarInstance0 = superBarProxy();
     superBarInstance0.call("setBar", 123);
-    POTHOS_TEST_EQUAL(superBarInstance0.call<int>("getBar"), 123);
+    POTHOS_TEST_EQUAL(superBarInstance0.call("getBar"), 123);
 
     //test field access
     superBarInstance0.set("_bar", 321);
@@ -99,7 +99,7 @@ static void test_simple_runner(Pothos::ProxyEnvironment::Sptr env)
 
     //make an instance and test
     auto superBarInstance1 = superBarProxy(21);
-    POTHOS_TEST_EQUAL(superBarInstance1.call<int>("getBar"), 21);
+    POTHOS_TEST_EQUAL(superBarInstance1.call("getBar"), 21);
 
     Pothos::ManagedClass()
         .registerClass<SuperFoo>()
@@ -113,12 +113,12 @@ static void test_simple_runner(Pothos::ProxyEnvironment::Sptr env)
 
     //test it making a super bar and test
     auto superBarInstance2 = superFooProxy.call("make", 4567);
-    POTHOS_TEST_EQUAL(superBarInstance2.call<int>("getBar"), 4567);
+    POTHOS_TEST_EQUAL(superBarInstance2.call("getBar"), 4567);
     auto superBarInstance3 = superFooProxy.call("makeNew", -543);
-    POTHOS_TEST_EQUAL(superBarInstance3.call<int>("getBar"), -543);
+    POTHOS_TEST_EQUAL(superBarInstance3.call("getBar"), -543);
     superBarInstance3.call("delete");
     auto superBarInstance4 = superFooProxy.call("makeShared", 987);
-    POTHOS_TEST_EQUAL(superBarInstance4.call<int>("getBar"), 987);
+    POTHOS_TEST_EQUAL(superBarInstance4.call("getBar"), 987);
 
     //runtime registration does not associate the module
     //therefore to be safe, we unregister these classes now
@@ -132,7 +132,7 @@ POTHOS_TEST_BLOCK("/proxy/remote/tests", test_inception)
 
     //spawn server and connect
     auto serverHandle1 = env->findProxy("Pothos/RemoteServer")("tcp://"+Pothos::Util::getWildcardAddr());
-    auto actualPort1 = serverHandle1.call<std::string>("getActualPort");
+    auto actualPort1 = serverHandle1.call("getActualPort");
     auto clientHandle1 = env->findProxy("Pothos/RemoteClient")("tcp://"+Pothos::Util::getLoopbackAddr(actualPort1));
 
     //create a remote environment
@@ -142,7 +142,7 @@ POTHOS_TEST_BLOCK("/proxy/remote/tests", test_inception)
     //now the remove env can make a new server
     //which can now be connected to locally
     auto serverHandle2 = remoteEnv->findProxy("Pothos/RemoteServer")("tcp://"+Pothos::Util::getWildcardAddr());
-    auto actualPort2 = serverHandle2.call<std::string>("getActualPort");
+    auto actualPort2 = serverHandle2.call("getActualPort");
     auto clientHandle2 = env->findProxy("Pothos/RemoteClient")("tcp://"+Pothos::Util::getLoopbackAddr(actualPort2));
 }
 
@@ -191,7 +191,7 @@ struct EchoTester
 
 static int callRemoteEcho(const Pothos::ProxyEnvironment::Sptr &env, int x)
 {
-    return env->findProxy("EchoTester").call<int>("echo", x);
+    return env->findProxy("EchoTester").call("echo", x);
 }
 
 POTHOS_TEST_BLOCK("/proxy/remote/tests", test_multithread_safe)

--- a/lib/Remote/Builtin/TestRemote.cpp
+++ b/lib/Remote/Builtin/TestRemote.cpp
@@ -86,12 +86,12 @@ static void test_simple_runner(Pothos::ProxyEnvironment::Sptr env)
     auto superBarProxy = env->findProxy("SuperBar");
 
     //test a static method
-    POTHOS_TEST_EQUAL(superBarProxy.call("what"), 42);
+    POTHOS_TEST_EQUAL(superBarProxy.call<int>("what"), 42);
 
     //make an instance and test
     auto superBarInstance0 = superBarProxy();
     superBarInstance0.call("setBar", 123);
-    POTHOS_TEST_EQUAL(superBarInstance0.call("getBar"), 123);
+    POTHOS_TEST_EQUAL(superBarInstance0.call<int>("getBar"), 123);
 
     //test field access
     superBarInstance0.set("_bar", 321);
@@ -99,7 +99,7 @@ static void test_simple_runner(Pothos::ProxyEnvironment::Sptr env)
 
     //make an instance and test
     auto superBarInstance1 = superBarProxy(21);
-    POTHOS_TEST_EQUAL(superBarInstance1.call("getBar"), 21);
+    POTHOS_TEST_EQUAL(superBarInstance1.call<int>("getBar"), 21);
 
     Pothos::ManagedClass()
         .registerClass<SuperFoo>()
@@ -113,12 +113,12 @@ static void test_simple_runner(Pothos::ProxyEnvironment::Sptr env)
 
     //test it making a super bar and test
     auto superBarInstance2 = superFooProxy.call("make", 4567);
-    POTHOS_TEST_EQUAL(superBarInstance2.call("getBar"), 4567);
+    POTHOS_TEST_EQUAL(superBarInstance2.call<int>("getBar"), 4567);
     auto superBarInstance3 = superFooProxy.call("makeNew", -543);
-    POTHOS_TEST_EQUAL(superBarInstance3.call("getBar"), -543);
+    POTHOS_TEST_EQUAL(superBarInstance3.call<int>("getBar"), -543);
     superBarInstance3.call("delete");
     auto superBarInstance4 = superFooProxy.call("makeShared", 987);
-    POTHOS_TEST_EQUAL(superBarInstance4.call("getBar"), 987);
+    POTHOS_TEST_EQUAL(superBarInstance4.call<int>("getBar"), 987);
 
     //runtime registration does not associate the module
     //therefore to be safe, we unregister these classes now

--- a/lib/Remote/RemoteProxy.cpp
+++ b/lib/Remote/RemoteProxy.cpp
@@ -118,9 +118,9 @@ RemoteProxyEnvironment::RemoteProxyEnvironment(
 
     //set the remote ID for this env
     remoteID = reply["envID"];
-    upid = reply["upid"].convert<std::string>();
-    nodeId = reply["nodeId"].convert<std::string>();
-    peerAddr = reply["peerAddr"].convert<std::string>();
+    upid = reply["upid"].operator std::string();
+    nodeId = reply["nodeId"].operator std::string();
+    peerAddr = reply["peerAddr"].operator std::string();
 }
 
 RemoteProxyEnvironment::~RemoteProxyEnvironment(void)

--- a/lib/Remote/RemoteProxy.cpp
+++ b/lib/Remote/RemoteProxy.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2016 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "RemoteProxy.hpp"
@@ -79,7 +79,7 @@ Pothos::ObjectKwargs RemoteProxyEnvironment::transact(const Pothos::ObjectKwargs
         isBlocking = false;
 
         //this is our thread ID, reply args
-        const auto replyTid = replyArgs.at("tid").convert<size_t>();
+        const size_t replyTid(replyArgs.at("tid"));
         if (replyTid == tid)
         {
             lock.unlock();
@@ -117,7 +117,7 @@ RemoteProxyEnvironment::RemoteProxyEnvironment(
         "RemoteProxyEnvironment()", errorMsgIt->second.extract<std::string>());
 
     //set the remote ID for this env
-    remoteID = reply["envID"].convert<size_t>();
+    remoteID = reply["envID"];
     upid = reply["upid"].convert<std::string>();
     nodeId = reply["nodeId"].convert<std::string>();
     peerAddr = reply["peerAddr"].convert<std::string>();
@@ -177,7 +177,7 @@ Pothos::Proxy RemoteProxyEnvironment::findProxy(const std::string &name)
         "RemoteProxyEnvironment::findProxy("+name+")", errorMsgIt->second.extract<std::string>());
 
     //otherwise make a handle
-    return this->makeHandle(reply["handleID"].convert<size_t>());
+    return this->makeHandle(reply["handleID"]);
 }
 
 Pothos::Proxy RemoteProxyEnvironment::convertObjectToProxy(const Pothos::Object &local)
@@ -196,7 +196,7 @@ Pothos::Proxy RemoteProxyEnvironment::convertObjectToProxy(const Pothos::Object 
         "RemoteProxyEnvironment::convertObjectToProxy()", errorMsgIt->second.extract<std::string>());
 
     //otherwise make a handle
-    return this->makeHandle(reply["handleID"].convert<size_t>());
+    return this->makeHandle(reply["handleID"]);
 }
 
 Pothos::Object RemoteProxyEnvironment::convertProxyToObject(const Pothos::Proxy &proxy)

--- a/lib/Remote/RemoteProxy.cpp
+++ b/lib/Remote/RemoteProxy.cpp
@@ -118,9 +118,9 @@ RemoteProxyEnvironment::RemoteProxyEnvironment(
 
     //set the remote ID for this env
     remoteID = reply["envID"];
-    upid = reply["upid"].operator std::string();
-    nodeId = reply["nodeId"].operator std::string();
-    peerAddr = reply["peerAddr"].operator std::string();
+    upid = reply["upid"].convert<std::string>();
+    nodeId = reply["nodeId"].convert<std::string>();
+    peerAddr = reply["peerAddr"].convert<std::string>();
 }
 
 RemoteProxyEnvironment::~RemoteProxyEnvironment(void)

--- a/lib/Remote/RemoteProxyHandle.cpp
+++ b/lib/Remote/RemoteProxyHandle.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2015 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "RemoteProxy.hpp"
@@ -64,7 +64,7 @@ Pothos::Proxy RemoteProxyHandle::call(const std::string &name, const Pothos::Pro
     if (messageIt != reply.end()) throw Pothos::ProxyExceptionMessage(messageIt->second.extract<std::string>());
 
     //otherwise make a handle
-    return env->makeHandle(reply["handleID"].convert<size_t>());
+    return env->makeHandle(reply["handleID"]);
 }
 
 int RemoteProxyHandle::compareTo(const Pothos::Proxy &proxy) const
@@ -93,7 +93,7 @@ int RemoteProxyHandle::compareTo(const Pothos::Proxy &proxy) const
     if (errorMsgIt != reply.end()) throw Pothos::ProxyCompareError(
         "RemoteProxyEnvironment::compareTo()", errorMsgIt->second.extract<std::string>());
 
-    return reply["result"].convert<int>();
+    return reply["result"];
 }
 
 size_t RemoteProxyHandle::hashCode(void) const
@@ -105,7 +105,7 @@ size_t RemoteProxyHandle::hashCode(void) const
 
     auto reply = env->transact(req);
 
-    return reply["result"].extract<size_t>();
+    return reply["result"];
 }
 
 std::string RemoteProxyHandle::toString(void) const
@@ -117,7 +117,7 @@ std::string RemoteProxyHandle::toString(void) const
 
     auto reply = env->transact(req);
 
-    return reply["result"].extract<std::string>();
+    return reply["result"];
 }
 
 std::string RemoteProxyHandle::getClassName(void) const
@@ -129,5 +129,5 @@ std::string RemoteProxyHandle::getClassName(void) const
 
     auto reply = env->transact(req);
 
-    return reply["result"].extract<std::string>();
+    return reply["result"];
 }

--- a/lib/Remote/ServerHandler.cpp
+++ b/lib/Remote/ServerHandler.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2014 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "RemoteProxyDatagram.hpp"
@@ -39,14 +39,14 @@ static Pothos::Object getNewObjectId(const Pothos::Object &obj)
 
 static Pothos::Object getObjectAtId(const Pothos::Object &id)
 {
-    const size_t key = id.convert<size_t>();
+    const size_t key(id);
     std::lock_guard<std::mutex> lock(getObjectsMutex());
     return getObjectsMap()[key];
 }
 
 static void removeObjectAtId(const Pothos::Object &id)
 {
-    const size_t key = id.convert<size_t>();
+    const size_t key(id);
     std::lock_guard<std::mutex> lock(getObjectsMutex());
     getObjectsMap().erase(key);
 }

--- a/lib/System/Version.in.cpp
+++ b/lib/System/Version.in.cpp
@@ -1,15 +1,17 @@
-// Copyright (c) 2013-2016 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/System/Version.hpp>
-#include <Poco/Format.h>
+#include <sstream>
 
 std::string Pothos::System::getApiVersion(void)
 {
-    return Poco::format("%d.%d.%d",
-        int((POTHOS_API_VERSION >> 24) & 0xf),
-        int((POTHOS_API_VERSION >> 16) & 0xf),
-        int((POTHOS_API_VERSION >> 0) & 0xff));
+    std::stringstream ss;
+    ss << std::hex << int((POTHOS_API_VERSION >> 24) & 0xff) << "."
+       << std::hex << int((POTHOS_API_VERSION >> 16) & 0xff) << "."
+       << std::hex << int((POTHOS_API_VERSION >> 0) & 0xffff)
+       << std::dec;
+    return ss.str();
 }
 
 std::string Pothos::System::getAbiVersion(void)

--- a/lib/Util/Builtin/DocUtils.cpp
+++ b/lib/Util/Builtin/DocUtils.cpp
@@ -48,7 +48,7 @@ public:
     static std::string dumpJsonAt(const std::string &path)
     {
         auto plugin = Pothos::PluginRegistry::get("/blocks/docs"+path);
-        return plugin.getObject().operator std::string();
+        return plugin.getObject().convert<std::string>();
     }
 };
 

--- a/lib/Util/Builtin/DocUtils.cpp
+++ b/lib/Util/Builtin/DocUtils.cpp
@@ -48,7 +48,7 @@ public:
     static std::string dumpJsonAt(const std::string &path)
     {
         auto plugin = Pothos::PluginRegistry::get("/blocks/docs"+path);
-        return plugin.getObject().convert<std::string>();
+        return plugin.getObject().operator std::string();
     }
 };
 

--- a/lib/Util/Builtin/TestDocUtils.cpp
+++ b/lib/Util/Builtin/TestDocUtils.cpp
@@ -15,7 +15,7 @@ POTHOS_TEST_BLOCK("/util/tests", test_doc_utils_dump_json)
     //check that the following does not throw
     auto env = Pothos::ProxyEnvironment::make("managed");
     auto proxy = env->findProxy("Pothos/Util/DocUtils");
-    const auto jsonStr = proxy.call<std::string>("dumpJson");
+    const std::string jsonStr = proxy.call("dumpJson");
     POTHOS_TEST_TRUE(not jsonStr.empty());
     if (jsonStr.size() > 100)
     {

--- a/lib/Util/Builtin/TestEvalExpression.cpp
+++ b/lib/Util/Builtin/TestEvalExpression.cpp
@@ -29,7 +29,7 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_expression)
 
     //a pothos type
     //const auto result2 = evalEnv.call<Pothos::Object>("eval", "DType(\"int32\")");
-    //POTHOS_TEST_TRUE(result2.convert<Pothos::DType>() == Pothos::DType(typeid(int)));
+    //POTHOS_TEST_TRUE((const Pothos::DType &)result2 == Pothos::DType(typeid(int)));
 
     //test string w/ escape quote
     const auto result3 = evalEnv.call<Pothos::Object>("eval", "\"hello \\\" world\"");
@@ -88,22 +88,22 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_list_expression)
     //a nested test
     {
         const auto result = evalEnv.call<Pothos::Object>("eval", "[1, [\"hello\", \"world\"], 3]");
-        const auto vec = result.convert<Pothos::ObjectVector>();
+        const Pothos::ObjectVector vec = result;
         POTHOS_TEST_EQUAL(vec.size(), 3);
-        POTHOS_TEST_EQUAL(vec[0].convert<int>(), 1);
-        const auto vec_1 = vec[1].convert<std::vector<std::string>>();
+        POTHOS_TEST_EQUAL(int(vec[0]), 1);
+        const std::vector<std::string> vec_1 = vec[1];
         POTHOS_TEST_EQUAL(vec_1.size(), 2);
         POTHOS_TEST_EQUAL(vec_1[0], "hello");
         POTHOS_TEST_EQUAL(vec_1[1], "world");
-        POTHOS_TEST_EQUAL(vec[2].convert<int>(), 3);
+        POTHOS_TEST_EQUAL(int(vec[2]), 3);
     }
 
     //an embedded function with commas
     {
         const auto result = evalEnv.call<Pothos::Object>("eval", "[pow(2, 3)]");
-        const auto vec = result.convert<Pothos::ObjectVector>();
+        const Pothos::ObjectVector vec = result;
         POTHOS_TEST_EQUAL(vec.size(), 1);
-        POTHOS_TEST_CLOSE(vec[0].convert<double>(), 8, 0.001);
+        POTHOS_TEST_CLOSE(double(vec[0]), 8, 0.001);
     }
 }
 
@@ -115,34 +115,34 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_map_expression)
     //the empty test
     {
         const auto result = evalEnv.call<Pothos::Object>("eval", "{}");
-        const auto map = result.convert<Pothos::ObjectMap>();
+        const Pothos::ObjectMap map = result;
         POTHOS_TEST_EQUAL(map.size(), 0);
     }
 
     //a simple test
     {
         const auto result = evalEnv.call<Pothos::Object>("eval", "{\"hello\" : 1, \"world\" : 2}");
-        const auto map = result.convert<Pothos::ObjectMap>();
+        const Pothos::ObjectMap map = result;
         POTHOS_TEST_EQUAL(map.size(), 2);
-        POTHOS_TEST_EQUAL(map.at(Pothos::Object("hello")).convert<int>(), 1);
-        POTHOS_TEST_EQUAL(map.at(Pothos::Object("world")).convert<int>(), 2);
+        POTHOS_TEST_EQUAL(int(map.at(Pothos::Object("hello"))), 1);
+        POTHOS_TEST_EQUAL(int(map.at(Pothos::Object("world"))), 2);
     }
 
     //a trailing comma test
     {
         const auto result = evalEnv.call<Pothos::Object>("eval", "{1:2, }");
-        const auto map = result.convert<Pothos::ObjectMap>();
+        const Pothos::ObjectMap map = result;
         POTHOS_TEST_EQUAL(map.size(), 1);
-        POTHOS_TEST_EQUAL(map.at(Pothos::Object(1)).convert<int>(), 2);
+        POTHOS_TEST_EQUAL(int(map.at(Pothos::Object(1))), 2);
     }
 
     //a nested test
     {
         const auto result = evalEnv.call<Pothos::Object>("eval", "{\"hello\" : 1, \"world\" : [1, 2, 3]}");
-        const auto map = result.convert<Pothos::ObjectMap>();
+        const Pothos::ObjectMap map = result;
         POTHOS_TEST_EQUAL(map.size(), 2);
-        POTHOS_TEST_EQUAL(map.at(Pothos::Object("hello")).convert<int>(), 1);
-        const auto vec_1 = map.at(Pothos::Object("world")).convert<std::vector<int>>();
+        POTHOS_TEST_EQUAL(int(map.at(Pothos::Object("hello"))), 1);
+        const std::vector<int> vec_1 = map.at(Pothos::Object("world"));
         POTHOS_TEST_EQUAL(vec_1.size(), 3);
         POTHOS_TEST_EQUAL(vec_1[0], 1);
         POTHOS_TEST_EQUAL(vec_1[1], 2);
@@ -160,14 +160,14 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_with_constants)
         evalEnv.call<Pothos::Object>("registerConstantExpr", "x", "1");
         evalEnv.call<Pothos::Object>("registerConstantExpr", "y", "2");
         const auto result = evalEnv.call<Pothos::Object>("eval", "x + y");
-        POTHOS_TEST_EQUAL(result.convert<int>(), 3);
+        POTHOS_TEST_EQUAL(int(result), 3);
     }
 
     //array math
     {
         evalEnv.call<Pothos::Object>("registerConstantExpr", "arr", "[1, 2, 3]");
         const auto result = evalEnv.call<Pothos::Object>("eval", "2*arr");
-        const auto vec = result.convert<std::vector<int>>();
+        const std::vector<int> vec = result;
         POTHOS_TEST_EQUAL(vec.size(), 3);
         POTHOS_TEST_EQUAL(vec[0], 2);
         POTHOS_TEST_EQUAL(vec[1], 4);
@@ -178,24 +178,24 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_with_constants)
     {
         evalEnv.call<Pothos::Object>("registerConstantExpr", "nested", "[1, [\"hello\", \"world\"], 3]");
         const auto result = evalEnv.call<Pothos::Object>("eval", "nested");
-        const auto vec = result.convert<Pothos::ObjectVector>();
+        const Pothos::ObjectVector vec = result;
         POTHOS_TEST_EQUAL(vec.size(), 3);
-        POTHOS_TEST_EQUAL(vec[0].convert<int>(), 1);
-        const auto vec_1 = vec[1].convert<std::vector<std::string>>();
+        POTHOS_TEST_EQUAL(int(vec[0]), 1);
+        const std::vector<std::string> vec_1 = vec[1];
         POTHOS_TEST_EQUAL(vec_1.size(), 2);
         POTHOS_TEST_EQUAL(vec_1[0], "hello");
         POTHOS_TEST_EQUAL(vec_1[1], "world");
-        POTHOS_TEST_EQUAL(vec[2].convert<int>(), 3);
+        POTHOS_TEST_EQUAL(int(vec[2]), 3);
     }
 
     //nested dict
      {
         evalEnv.call<Pothos::Object>("registerConstantExpr", "nested", "{\"hello\" : 1, \"world\" : [1, 2, 3]}");
         const auto result = evalEnv.call<Pothos::Object>("eval", "nested");
-        const auto map = result.convert<Pothos::ObjectMap>();
+        const Pothos::ObjectMap map = result;
         POTHOS_TEST_EQUAL(map.size(), 2);
-        POTHOS_TEST_EQUAL(map.at(Pothos::Object("hello")).convert<int>(), 1);
-        const auto vec_1 = map.at(Pothos::Object("world")).convert<std::vector<int>>();
+        POTHOS_TEST_EQUAL(int(map.at(Pothos::Object("hello"))), 1);
+        const std::vector<int> vec_1 = map.at(Pothos::Object("world"));
         POTHOS_TEST_EQUAL(vec_1.size(), 3);
         POTHOS_TEST_EQUAL(vec_1[0], 1);
         POTHOS_TEST_EQUAL(vec_1[1], 2);
@@ -213,7 +213,7 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_constant_obj)
         const auto arg = short(123);
         evalEnv.call<Pothos::Object>("registerConstantObj", "v0", arg);
         const auto result = evalEnv.call<Pothos::Object>("eval", "v0");
-        POTHOS_TEST_EQUAL(result.convert<short>(), arg);
+        POTHOS_TEST_EQUAL(short(result), arg);
     }
 
     //float type
@@ -221,7 +221,7 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_constant_obj)
         const auto arg = float(-10.0);
         evalEnv.call<Pothos::Object>("registerConstantObj", "v1", arg);
         const auto result = evalEnv.call<Pothos::Object>("eval", "v1");
-        POTHOS_TEST_EQUAL(result.convert<float>(), arg);
+        POTHOS_TEST_EQUAL(float(result), arg);
     }
 
     //complex float
@@ -229,7 +229,7 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_constant_obj)
         const auto arg = std::complex<float>(11.0, -32.0);
         evalEnv.call<Pothos::Object>("registerConstantObj", "v2", arg);
         const auto result = evalEnv.call<Pothos::Object>("eval", "v2");
-        POTHOS_TEST_EQUAL(result.convert<std::complex<float>>(), arg);
+        POTHOS_TEST_EQUAL((const std::complex<float> &)result, arg);
     }
 
     //long long type
@@ -237,7 +237,7 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_constant_obj)
         const auto arg = (long long)(17179869184ll);
         evalEnv.call<Pothos::Object>("registerConstantObj", "v3", arg);
         const auto result = evalEnv.call<Pothos::Object>("eval", "v3");
-        POTHOS_TEST_EQUAL(result.convert<long long>(), arg);
+        POTHOS_TEST_EQUAL((long long)result, arg);
     }
 
     //numeric vector
@@ -248,7 +248,7 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_constant_obj)
         arg.push_back(3);
         evalEnv.call<Pothos::Object>("registerConstantObj", "v4", arg);
         const auto result = evalEnv.call<Pothos::Object>("eval", "v4");
-        const auto vec = result.convert<std::vector<int>>();
+        const std::vector<int> vec = result;
         POTHOS_TEST_EQUAL(vec.size(), 3);
         POTHOS_TEST_EQUAL(vec[0], 1);
         POTHOS_TEST_EQUAL(vec[1], 2);

--- a/lib/Util/Builtin/TestEvalExpression.cpp
+++ b/lib/Util/Builtin/TestEvalExpression.cpp
@@ -25,7 +25,7 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_expression)
 
     //simple expression
     const auto result = evalEnv.call<Pothos::Object>("eval", "1 + 2");
-    POTHOS_TEST_EQUAL(result, 3);
+    POTHOS_TEST_EQUAL(int(result), 3);
 
     //a pothos type
     //const auto result2 = evalEnv.call<Pothos::Object>("eval", "DType(\"int32\")");
@@ -90,12 +90,12 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_list_expression)
         const auto result = evalEnv.call<Pothos::Object>("eval", "[1, [\"hello\", \"world\"], 3]");
         const Pothos::ObjectVector vec = result;
         POTHOS_TEST_EQUAL(vec.size(), 3);
-        POTHOS_TEST_EQUAL(vec[0], 1);
+        POTHOS_TEST_EQUAL(int(vec[0]), 1);
         const std::vector<std::string> vec_1 = vec[1];
         POTHOS_TEST_EQUAL(vec_1.size(), 2);
         POTHOS_TEST_EQUAL(vec_1[0], "hello");
         POTHOS_TEST_EQUAL(vec_1[1], "world");
-        POTHOS_TEST_EQUAL(vec[2], 3);
+        POTHOS_TEST_EQUAL(int(vec[2]), 3);
     }
 
     //an embedded function with commas
@@ -124,8 +124,8 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_map_expression)
         const auto result = evalEnv.call<Pothos::Object>("eval", "{\"hello\" : 1, \"world\" : 2}");
         const Pothos::ObjectMap map = result;
         POTHOS_TEST_EQUAL(map.size(), 2);
-        POTHOS_TEST_EQUAL(map.at(Pothos::Object("hello")), 1);
-        POTHOS_TEST_EQUAL(map.at(Pothos::Object("world")), 2);
+        POTHOS_TEST_EQUAL(int(map.at(Pothos::Object("hello"))), 1);
+        POTHOS_TEST_EQUAL(int(map.at(Pothos::Object("world"))), 2);
     }
 
     //a trailing comma test
@@ -133,7 +133,7 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_map_expression)
         const auto result = evalEnv.call<Pothos::Object>("eval", "{1:2, }");
         const Pothos::ObjectMap map = result;
         POTHOS_TEST_EQUAL(map.size(), 1);
-        POTHOS_TEST_EQUAL(map.at(Pothos::Object(1)), 2);
+        POTHOS_TEST_EQUAL(int(map.at(Pothos::Object(1))), 2);
     }
 
     //a nested test
@@ -141,7 +141,7 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_map_expression)
         const auto result = evalEnv.call<Pothos::Object>("eval", "{\"hello\" : 1, \"world\" : [1, 2, 3]}");
         const Pothos::ObjectMap map = result;
         POTHOS_TEST_EQUAL(map.size(), 2);
-        POTHOS_TEST_EQUAL(map.at(Pothos::Object("hello")), 1);
+        POTHOS_TEST_EQUAL(int(map.at(Pothos::Object("hello"))), 1);
         const std::vector<int> vec_1 = map.at(Pothos::Object("world"));
         POTHOS_TEST_EQUAL(vec_1.size(), 3);
         POTHOS_TEST_EQUAL(vec_1[0], 1);
@@ -160,7 +160,7 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_with_constants)
         evalEnv.call<Pothos::Object>("registerConstantExpr", "x", "1");
         evalEnv.call<Pothos::Object>("registerConstantExpr", "y", "2");
         const auto result = evalEnv.call<Pothos::Object>("eval", "x + y");
-        POTHOS_TEST_EQUAL(result, 3);
+        POTHOS_TEST_EQUAL(int(result), 3);
     }
 
     //array math
@@ -180,12 +180,12 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_with_constants)
         const auto result = evalEnv.call<Pothos::Object>("eval", "nested");
         const Pothos::ObjectVector vec = result;
         POTHOS_TEST_EQUAL(vec.size(), 3);
-        POTHOS_TEST_EQUAL(vec[0], 1);
+        POTHOS_TEST_EQUAL(int(vec[0]), 1);
         const std::vector<std::string> vec_1 = vec[1];
         POTHOS_TEST_EQUAL(vec_1.size(), 2);
         POTHOS_TEST_EQUAL(vec_1[0], "hello");
         POTHOS_TEST_EQUAL(vec_1[1], "world");
-        POTHOS_TEST_EQUAL(vec[2], 3);
+        POTHOS_TEST_EQUAL(int(vec[2]), 3);
     }
 
     //nested dict
@@ -194,7 +194,7 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_with_constants)
         const auto result = evalEnv.call<Pothos::Object>("eval", "nested");
         const Pothos::ObjectMap map = result;
         POTHOS_TEST_EQUAL(map.size(), 2);
-        POTHOS_TEST_EQUAL(map.at(Pothos::Object("hello")), 1);
+        POTHOS_TEST_EQUAL(int(map.at(Pothos::Object("hello"))), 1);
         const std::vector<int> vec_1 = map.at(Pothos::Object("world"));
         POTHOS_TEST_EQUAL(vec_1.size(), 3);
         POTHOS_TEST_EQUAL(vec_1[0], 1);
@@ -213,7 +213,7 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_constant_obj)
         const auto arg = short(123);
         evalEnv.call<Pothos::Object>("registerConstantObj", "v0", arg);
         const auto result = evalEnv.call<Pothos::Object>("eval", "v0");
-        POTHOS_TEST_EQUAL(result, arg);
+        POTHOS_TEST_EQUAL(short(result), arg);
     }
 
     //float type
@@ -221,7 +221,7 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_constant_obj)
         const auto arg = float(-10.0);
         evalEnv.call<Pothos::Object>("registerConstantObj", "v1", arg);
         const auto result = evalEnv.call<Pothos::Object>("eval", "v1");
-        POTHOS_TEST_EQUAL(result, arg);
+        POTHOS_TEST_EQUAL(float(result), arg);
     }
 
     //complex float
@@ -237,7 +237,7 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_constant_obj)
         const auto arg = (long long)(17179869184ll);
         evalEnv.call<Pothos::Object>("registerConstantObj", "v3", arg);
         const auto result = evalEnv.call<Pothos::Object>("eval", "v3");
-        POTHOS_TEST_EQUAL((long long)result, arg);
+        POTHOS_TEST_EQUAL(result.convert<long long>(), arg);
     }
 
     //numeric vector

--- a/lib/Util/Builtin/TestEvalExpression.cpp
+++ b/lib/Util/Builtin/TestEvalExpression.cpp
@@ -18,14 +18,14 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_expression)
 
     //booleans
     const auto resultT = evalEnv.call<Pothos::Object>("eval", "true");
-    POTHOS_TEST_TRUE((const bool&)resultT);
+    POTHOS_TEST_TRUE(resultT.convert<bool>());
 
     const auto resultF = evalEnv.call<Pothos::Object>("eval", "false");
-    POTHOS_TEST_TRUE(not (const bool&)resultF);
+    POTHOS_TEST_TRUE(not resultF.convert<bool>());
 
     //simple expression
     const auto result = evalEnv.call<Pothos::Object>("eval", "1 + 2");
-    POTHOS_TEST_EQUAL(int(result), 3);
+    POTHOS_TEST_EQUAL(result, 3);
 
     //a pothos type
     //const auto result2 = evalEnv.call<Pothos::Object>("eval", "DType(\"int32\")");
@@ -33,7 +33,7 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_expression)
 
     //test string w/ escape quote
     const auto result3 = evalEnv.call<Pothos::Object>("eval", "\"hello \\\" world\"");
-    POTHOS_TEST_EQUAL((const std::string &)result3, "hello \" world");
+    POTHOS_TEST_EQUAL(result3.convert<std::string>(), "hello \" world");
 }
 
 POTHOS_TEST_BLOCK("/util/tests", test_eval_list_expression)
@@ -90,12 +90,12 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_list_expression)
         const auto result = evalEnv.call<Pothos::Object>("eval", "[1, [\"hello\", \"world\"], 3]");
         const Pothos::ObjectVector vec = result;
         POTHOS_TEST_EQUAL(vec.size(), 3);
-        POTHOS_TEST_EQUAL(int(vec[0]), 1);
+        POTHOS_TEST_EQUAL(vec[0], 1);
         const std::vector<std::string> vec_1 = vec[1];
         POTHOS_TEST_EQUAL(vec_1.size(), 2);
         POTHOS_TEST_EQUAL(vec_1[0], "hello");
         POTHOS_TEST_EQUAL(vec_1[1], "world");
-        POTHOS_TEST_EQUAL(int(vec[2]), 3);
+        POTHOS_TEST_EQUAL(vec[2], 3);
     }
 
     //an embedded function with commas
@@ -124,8 +124,8 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_map_expression)
         const auto result = evalEnv.call<Pothos::Object>("eval", "{\"hello\" : 1, \"world\" : 2}");
         const Pothos::ObjectMap map = result;
         POTHOS_TEST_EQUAL(map.size(), 2);
-        POTHOS_TEST_EQUAL(int(map.at(Pothos::Object("hello"))), 1);
-        POTHOS_TEST_EQUAL(int(map.at(Pothos::Object("world"))), 2);
+        POTHOS_TEST_EQUAL(map.at(Pothos::Object("hello")), 1);
+        POTHOS_TEST_EQUAL(map.at(Pothos::Object("world")), 2);
     }
 
     //a trailing comma test
@@ -133,7 +133,7 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_map_expression)
         const auto result = evalEnv.call<Pothos::Object>("eval", "{1:2, }");
         const Pothos::ObjectMap map = result;
         POTHOS_TEST_EQUAL(map.size(), 1);
-        POTHOS_TEST_EQUAL(int(map.at(Pothos::Object(1))), 2);
+        POTHOS_TEST_EQUAL(map.at(Pothos::Object(1)), 2);
     }
 
     //a nested test
@@ -141,7 +141,7 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_map_expression)
         const auto result = evalEnv.call<Pothos::Object>("eval", "{\"hello\" : 1, \"world\" : [1, 2, 3]}");
         const Pothos::ObjectMap map = result;
         POTHOS_TEST_EQUAL(map.size(), 2);
-        POTHOS_TEST_EQUAL(int(map.at(Pothos::Object("hello"))), 1);
+        POTHOS_TEST_EQUAL(map.at(Pothos::Object("hello")), 1);
         const std::vector<int> vec_1 = map.at(Pothos::Object("world"));
         POTHOS_TEST_EQUAL(vec_1.size(), 3);
         POTHOS_TEST_EQUAL(vec_1[0], 1);
@@ -160,7 +160,7 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_with_constants)
         evalEnv.call<Pothos::Object>("registerConstantExpr", "x", "1");
         evalEnv.call<Pothos::Object>("registerConstantExpr", "y", "2");
         const auto result = evalEnv.call<Pothos::Object>("eval", "x + y");
-        POTHOS_TEST_EQUAL(int(result), 3);
+        POTHOS_TEST_EQUAL(result, 3);
     }
 
     //array math
@@ -180,12 +180,12 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_with_constants)
         const auto result = evalEnv.call<Pothos::Object>("eval", "nested");
         const Pothos::ObjectVector vec = result;
         POTHOS_TEST_EQUAL(vec.size(), 3);
-        POTHOS_TEST_EQUAL(int(vec[0]), 1);
+        POTHOS_TEST_EQUAL(vec[0], 1);
         const std::vector<std::string> vec_1 = vec[1];
         POTHOS_TEST_EQUAL(vec_1.size(), 2);
         POTHOS_TEST_EQUAL(vec_1[0], "hello");
         POTHOS_TEST_EQUAL(vec_1[1], "world");
-        POTHOS_TEST_EQUAL(int(vec[2]), 3);
+        POTHOS_TEST_EQUAL(vec[2], 3);
     }
 
     //nested dict
@@ -194,7 +194,7 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_with_constants)
         const auto result = evalEnv.call<Pothos::Object>("eval", "nested");
         const Pothos::ObjectMap map = result;
         POTHOS_TEST_EQUAL(map.size(), 2);
-        POTHOS_TEST_EQUAL(int(map.at(Pothos::Object("hello"))), 1);
+        POTHOS_TEST_EQUAL(map.at(Pothos::Object("hello")), 1);
         const std::vector<int> vec_1 = map.at(Pothos::Object("world"));
         POTHOS_TEST_EQUAL(vec_1.size(), 3);
         POTHOS_TEST_EQUAL(vec_1[0], 1);
@@ -213,7 +213,7 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_constant_obj)
         const auto arg = short(123);
         evalEnv.call<Pothos::Object>("registerConstantObj", "v0", arg);
         const auto result = evalEnv.call<Pothos::Object>("eval", "v0");
-        POTHOS_TEST_EQUAL(short(result), arg);
+        POTHOS_TEST_EQUAL(result, arg);
     }
 
     //float type
@@ -221,7 +221,7 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_constant_obj)
         const auto arg = float(-10.0);
         evalEnv.call<Pothos::Object>("registerConstantObj", "v1", arg);
         const auto result = evalEnv.call<Pothos::Object>("eval", "v1");
-        POTHOS_TEST_EQUAL(float(result), arg);
+        POTHOS_TEST_EQUAL(result, arg);
     }
 
     //complex float
@@ -229,7 +229,7 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_constant_obj)
         const auto arg = std::complex<float>(11.0, -32.0);
         evalEnv.call<Pothos::Object>("registerConstantObj", "v2", arg);
         const auto result = evalEnv.call<Pothos::Object>("eval", "v2");
-        POTHOS_TEST_EQUAL((const std::complex<float> &)result, arg);
+        POTHOS_TEST_EQUAL(result.convert<std::complex<float>>(), arg);
     }
 
     //long long type

--- a/lib/Util/Builtin/TestEvalExpression.cpp
+++ b/lib/Util/Builtin/TestEvalExpression.cpp
@@ -18,14 +18,14 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_expression)
 
     //booleans
     const auto resultT = evalEnv.call<Pothos::Object>("eval", "true");
-    POTHOS_TEST_TRUE(resultT.convert<bool>());
+    POTHOS_TEST_TRUE(bool(resultT));
 
     const auto resultF = evalEnv.call<Pothos::Object>("eval", "false");
-    POTHOS_TEST_TRUE(not resultF.convert<bool>());
+    POTHOS_TEST_TRUE(not (const bool&)resultF);
 
     //simple expression
     const auto result = evalEnv.call<Pothos::Object>("eval", "1 + 2");
-    POTHOS_TEST_EQUAL(result.convert<int>(), 3);
+    POTHOS_TEST_EQUAL(int(result), 3);
 
     //a pothos type
     //const auto result2 = evalEnv.call<Pothos::Object>("eval", "DType(\"int32\")");
@@ -33,7 +33,7 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_expression)
 
     //test string w/ escape quote
     const auto result3 = evalEnv.call<Pothos::Object>("eval", "\"hello \\\" world\"");
-    POTHOS_TEST_EQUAL(result3.convert<std::string>(), "hello \" world");
+    POTHOS_TEST_EQUAL((const std::string &)result3, "hello \" world");
 }
 
 POTHOS_TEST_BLOCK("/util/tests", test_eval_list_expression)
@@ -44,14 +44,14 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_list_expression)
     //the empty test
     {
         const auto result = evalEnv.call<Pothos::Object>("eval", "[]");
-        const auto vec = result.convert<std::vector<int>>();
+        const std::vector<int> vec = result;
         POTHOS_TEST_EQUAL(vec.size(), 0);
     }
 
     //a simple test
     {
         const auto result = evalEnv.call<Pothos::Object>("eval", "[1, 2, 3]");
-        const auto vec = result.convert<std::vector<int>>();
+        const std::vector<int> vec = result;
         POTHOS_TEST_EQUAL(vec.size(), 3);
         POTHOS_TEST_EQUAL(vec[0], 1);
         POTHOS_TEST_EQUAL(vec[1], 2);
@@ -61,7 +61,7 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_list_expression)
     //array math
     {
         const auto result = evalEnv.call<Pothos::Object>("eval", "(2 * [1, 2, 3]) + [3, 2, 1]");
-        const auto vec = result.convert<std::vector<int>>();
+        const std::vector<int> vec = result;
         POTHOS_TEST_EQUAL(vec.size(), 3);
         POTHOS_TEST_EQUAL(vec[0], 2*1 + 3);
         POTHOS_TEST_EQUAL(vec[1], 2*2 + 2);
@@ -71,7 +71,7 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_list_expression)
     //a trailing comma test
     {
         const auto result = evalEnv.call<Pothos::Object>("eval", "[1, ]");
-        const auto vec = result.convert<std::vector<int>>();
+        const std::vector<int> vec = result;
         POTHOS_TEST_EQUAL(vec.size(), 1);
         POTHOS_TEST_EQUAL(vec[0], 1);
     }
@@ -79,7 +79,7 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_list_expression)
     //a quote test (including commas and escapes)
     {
         const auto result = evalEnv.call<Pothos::Object>("eval", "[\"comma, \\\"comma, comma, \", \"chameleon\"]");
-        const auto vec = result.convert<std::vector<std::string>>();
+        const std::vector<std::string> vec = result;
         POTHOS_TEST_EQUAL(vec.size(), 2);
         POTHOS_TEST_EQUAL(vec[0], "comma, \"comma, comma, ");
         POTHOS_TEST_EQUAL(vec[1], "chameleon");

--- a/lib/Util/Builtin/TestEvalExpression.cpp
+++ b/lib/Util/Builtin/TestEvalExpression.cpp
@@ -18,7 +18,7 @@ POTHOS_TEST_BLOCK("/util/tests", test_eval_expression)
 
     //booleans
     const auto resultT = evalEnv.call<Pothos::Object>("eval", "true");
-    POTHOS_TEST_TRUE(bool(resultT));
+    POTHOS_TEST_TRUE((const bool&)resultT);
 
     const auto resultF = evalEnv.call<Pothos::Object>("eval", "false");
     POTHOS_TEST_TRUE(not (const bool&)resultF);

--- a/lib/Util/Compiler.cpp
+++ b/lib/Util/Compiler.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Util/Compiler.hpp>
@@ -74,7 +74,7 @@ Pothos::Util::Compiler::Sptr Pothos::Util::Compiler::make(const std::string &nam
     {
         auto plugin = Pothos::PluginRegistry::get(Pothos::PluginPath("/util/compiler").join(name));
         auto callable = plugin.getObject().extract<Pothos::Callable>();
-        compiler = callable.call<Sptr>();
+        compiler = callable.call();
     }
     catch(const Exception &ex)
     {

--- a/lib/Util/EvalEnvironment.cpp
+++ b/lib/Util/EvalEnvironment.cpp
@@ -75,18 +75,18 @@ static mup::Value objectToMupValue(const Pothos::Object &obj)
     try
     {
         Pothos::DType dtype(obj.type());
-        if (dtype.isComplex()) return mup::Value(obj.convert<mup::cmplx_type>());
-        if (dtype.isFloat()) return mup::Value(obj.convert<mup::float_type>());
+        if (dtype.isComplex()) return mup::Value(obj.operator mup::cmplx_type());
+        if (dtype.isFloat()) return mup::Value(obj.operator mup::float_type());
         //types that fit into the parser's integer type, otherwise use floating point
-        if (dtype.size() <= sizeof(mup::int_type)) return mup::Value(obj.convert<mup::int_type>());
-        else return mup::Value(obj.convert<mup::float_type>());
+        if (dtype.size() <= sizeof(mup::int_type)) return mup::Value(obj.operator mup::int_type());
+        else return mup::Value(obj.operator mup::float_type());
     }
     catch (...) {}
 
     //support proxy vector to parser array
     if (obj.canConvert(typeid(Pothos::ProxyVector)))
     {
-        const auto vec = obj.convert<Pothos::ProxyVector>();
+        const Pothos::ProxyVector vec = obj;
         mup::Value arr(1, vec.size(), 0.0);
         for (size_t i = 0; i < vec.size(); i++)
         {
@@ -98,7 +98,7 @@ static mup::Value objectToMupValue(const Pothos::Object &obj)
     //support proxy map to parser array
     if (obj.canConvert(typeid(Pothos::ProxyMap)))
     {
-        const auto map = obj.convert<Pothos::ProxyMap>();
+        const Pothos::ProxyMap map = obj;
         mup::Value arr(1, map.size()*2+1, 0.0);
         size_t i = 0;
         arr.At(0, i++) = mup::Value(mapTypeId);

--- a/lib/Util/EvalEnvironment.cpp
+++ b/lib/Util/EvalEnvironment.cpp
@@ -75,11 +75,11 @@ static mup::Value objectToMupValue(const Pothos::Object &obj)
     try
     {
         Pothos::DType dtype(obj.type());
-        if (dtype.isComplex()) return mup::Value(obj.operator mup::cmplx_type());
-        if (dtype.isFloat()) return mup::Value(obj.operator mup::float_type());
+        if (dtype.isComplex()) return mup::Value(obj.convert<mup::cmplx_type>());
+        if (dtype.isFloat()) return mup::Value(obj.convert<mup::float_type>());
         //types that fit into the parser's integer type, otherwise use floating point
-        if (dtype.size() <= sizeof(mup::int_type)) return mup::Value(obj.operator mup::int_type());
-        else return mup::Value(obj.operator mup::float_type());
+        if (dtype.size() <= sizeof(mup::int_type)) return mup::Value(obj.convert<mup::int_type>());
+        else return mup::Value(obj.convert<mup::float_type>());
     }
     catch (...) {}
 


### PR DESCRIPTION
Rather wordy function calls have been replaced with simply "call". Callable interface and Proxy classes both support using call for void/object/and templated return types. Old calls have been deprecated, but will remain in place for the next release.

In addition Object and Proxy support implicit templated conversion operator so they can be assigned to a type without an explicit function call or templated argument.

Example: `int x = obj.convert<int>()` becomes `int x = obj`
Or `int x = func.call<int>("foo", a1, a2)` becomes `int x = func.call("foo", a1, a2)`

**Note1:** The previous syntax here is not changing or going away. Both are supported and will continue to work.

**Note2:** The core library was updated to use these changes, and the tool kits and examples will be as well.

Changelog:

  * Object supports implicit templated convert to target type
  * Proxy supports implicit templated convert to target type
  * Deprecated Callable interface's callVoid(), use call()
  * Deprecated Callable interface's callObject(), use call()
  * Deprecated Proxy interface's callVoid(), use call()
  * Deprecated Proxy interface's callProxy(), use call()