### PR TITLE
removing uncessary locking

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3,6 +3,7 @@ This this the changelog file for the Pothos C++ library.
 Release 0.6.0 (pending)
 ==========================
 
+- Added Pothos::Util::SpinLockRW for single write, multi-read
 - API changes to Object, Proxy, and Callable interface types
   * Object supports implicit templated convert to target type
   * Proxy supports implicit templated convert to target type

--- a/include/Pothos/Util/SpinLockRW.hpp
+++ b/include/Pothos/Util/SpinLockRW.hpp
@@ -1,0 +1,138 @@
+///
+/// \file Util/SpinLockRW.hpp
+///
+/// A read/write spinlock implementation
+///
+/// \copyright
+/// Copyright (c) 2017-2017 Josh Blum
+/// SPDX-License-Identifier: BSL-1.0
+///
+
+#pragma once
+#include <Pothos/Config.hpp>
+#include <thread>
+#include <atomic>
+
+namespace Pothos {
+namespace Util {
+
+/*!
+ * Implementation of SharedLock
+ * Switch to std::shared_lock for C++14
+ */
+template <typename T>
+class SharedLock
+{
+public:
+    SharedLock(T &mutex):
+        _mutex(mutex)
+    {
+        _mutex.lock_shared();
+    }
+
+    ~SharedLock(void)
+    {
+        _mutex.unlock_shared();
+    }
+
+private:
+    T &_mutex;
+};
+
+/*!
+ * A spin lock that supports multiple readers + single writer.
+ * This lock is optimized for infrequent writes and frequent reading.
+ * Its primarily used in the core library for certain plugin hooks
+ * which require write locks during the plugin's loader hooks but
+ * then requires almost exclusively reads during runtime operation.
+ *
+ * - For writers, use with std::lock_guard<Pothos::Util::SpinLock>
+ * - For readers, use with Pothos::Util::SpinLockRW::SharedLock
+ */
+class POTHOS_API SpinLockRW
+{
+public:
+
+    //! Convenient typedef for shared lock type
+    typedef Pothos::Util::SharedLock<SpinLockRW> SharedLock;
+
+    //! Create a new unlocked spin lock
+    SpinLockRW(void);
+
+    //! Try to lock shared, return true for lock
+    bool try_lock_shared(void) noexcept;
+
+    //! Lock for multiple reader access
+    void lock_shared(void) noexcept;
+
+    //! Unlock from multiple reader access
+    void unlock_shared(void) noexcept;
+
+    //! Try to lock, return true for lock
+    bool try_lock(void) noexcept;
+
+    //! Lock for single writer access
+    void lock(void) noexcept;
+
+    //! Unlock single writer access
+    void unlock(void) noexcept;
+
+private:
+    enum : unsigned {WRITER_LOCK = unsigned(~0), UNLOCKED = 0};
+    std::atomic<unsigned> _lock;
+};
+
+} //namespace Util
+} //namespace Pothos
+
+
+inline Pothos::Util::SpinLockRW::SpinLockRW(void)
+{
+    this->unlock();
+}
+
+inline bool Pothos::Util::SpinLockRW::try_lock_shared(void) noexcept
+{
+    //true when the expected condition is not write lock
+    //and swap in the value of expected +1 (additional reader)
+    unsigned expected = _lock.load(std::memory_order_acquire);
+    return expected != WRITER_LOCK and _lock.compare_exchange_weak(expected, expected+1, std::memory_order_acq_rel);
+}
+
+inline void Pothos::Util::SpinLockRW::lock_shared(void) noexcept
+{
+    size_t count(0);
+    while (not this->try_lock_shared())
+    {
+        if (++count > 1024) std::this_thread::yield();
+    }
+}
+
+inline void Pothos::Util::SpinLockRW::unlock_shared(void) noexcept
+{
+    //decrement the reader count by 1
+    _lock.fetch_sub(1, std::memory_order_release);
+}
+
+inline bool Pothos::Util::SpinLockRW::try_lock(void) noexcept
+{
+    //true when the expected condition is unlocked (no readers)
+    //and swap in the value of write lock (one writer)
+    unsigned expected = UNLOCKED;
+    return _lock.compare_exchange_weak(expected, WRITER_LOCK, std::memory_order_acq_rel);
+}
+
+inline void Pothos::Util::SpinLockRW::lock(void) noexcept
+{
+    size_t count(0);
+    while (not this->try_lock())
+    {
+        if (++count > 1024) std::this_thread::yield();
+    }
+}
+
+inline void Pothos::Util::SpinLockRW::unlock(void) noexcept
+{
+    //restore to unlocked (no writer, no readers)
+    _lock.store(UNLOCKED, std::memory_order_release);
+}

--- a/lib/Framework/BufferChunk.cpp
+++ b/lib/Framework/BufferChunk.cpp
@@ -1,14 +1,13 @@
-// Copyright (c) 2013-2016 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Framework/BufferChunk.hpp>
-#include <Poco/SingletonHolder.h>
 #include <cstring> //memcpy
 
 const Pothos::BufferChunk &Pothos::BufferChunk::null(void)
 {
-    static Poco::SingletonHolder<BufferChunk> sh;
-    return *sh.get();
+    static BufferChunk nullChunk;
+    return nullChunk;
 }
 
 void Pothos::BufferChunk::append(const BufferChunk &other)

--- a/lib/Framework/BufferConvert.cpp
+++ b/lib/Framework/BufferConvert.cpp
@@ -1,9 +1,8 @@
-// Copyright (c) 2013-2016 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Framework/BufferChunk.hpp>
 #include <Pothos/Framework/Exception.hpp>
-#include <Poco/SingletonHolder.h>
 #include <functional>
 #include <complex>
 #include <cstdint>
@@ -119,8 +118,8 @@ private:
 
 static BufferConvertImpl &getBufferConvertImpl(void)
 {
-    static Poco::SingletonHolder<BufferConvertImpl> sh;
-    return *sh.get();
+    static BufferConvertImpl impl;
+    return impl;
 }
 
 /***********************************************************************

--- a/lib/Framework/DType.cpp
+++ b/lib/Framework/DType.cpp
@@ -4,7 +4,6 @@
 #include <Pothos/Framework/DType.hpp>
 #include <Pothos/Framework/Exception.hpp>
 #include <Pothos/Util/TypeInfo.hpp>
-#include <Poco/SingletonHolder.h>
 #include <Poco/StringTokenizer.h>
 #include <Poco/RegularExpression.h>
 #include <Poco/HashMap.h>
@@ -165,8 +164,8 @@ private:
 
 static ElementTypeSuperMap &getElementTypeSuperMap(void)
 {
-    static Poco::SingletonHolder<ElementTypeSuperMap> sh;
-    return *sh.get();
+    static ElementTypeSuperMap map;
+    return map;
 }
 
 /***********************************************************************

--- a/lib/Framework/SharedBuffer.cpp
+++ b/lib/Framework/SharedBuffer.cpp
@@ -3,7 +3,6 @@
 
 #include <Pothos/Framework/SharedBuffer.hpp>
 #include <Pothos/Framework/Exception.hpp>
-#include <Poco/SingletonHolder.h>
 #include <algorithm> //min/max
 #include <mutex>
 
@@ -39,8 +38,8 @@ Pothos::SharedBuffer::SharedBuffer(const size_t address, const size_t length, co
  **********************************************************************/
 static std::mutex &getCircMutex(void)
 {
-    static Poco::SingletonHolder<std::mutex> sh;
-    return *sh.get();
+    static std::mutex mutex;
+    return mutex;
 }
 
 Pothos::SharedBuffer Pothos::SharedBuffer::makeCirc(const size_t numBytes, const long nodeAffinity)

--- a/lib/Init.cpp
+++ b/lib/Init.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2016 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Init.hpp>
@@ -8,7 +8,6 @@
 #include <Poco/Path.h>
 #include <Poco/File.h>
 #include <Poco/Format.h>
-#include <Poco/SingletonHolder.h>
 
 //from lib/Framework/ConfLoader.cpp
 std::vector<Pothos::PluginPath> Pothos_ConfLoader_loadConfFiles(void);
@@ -35,8 +34,8 @@ namespace Pothos {
 
 Pothos::InitSingleton &Pothos::InitSingleton::instance(void)
 {
-    static Poco::SingletonHolder<Pothos::InitSingleton> sh;
-    return *sh.get();
+    static Pothos::InitSingleton inst;
+    return inst;
 }
 
 void Pothos::InitSingleton::load(void)

--- a/lib/Object/Hash.cpp
+++ b/lib/Object/Hash.cpp
@@ -1,31 +1,31 @@
-// Copyright (c) 2013-2016 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Object/Object.hpp>
 #include <Pothos/Object/Exception.hpp>
+#include <Pothos/Util/SpinLockRW.hpp>
 #include <Pothos/Callable.hpp>
 #include <Pothos/Plugin.hpp>
-#include <Poco/SingletonHolder.h>
-#include <Poco/RWLock.h>
 #include <Poco/Logger.h>
 #include <Poco/Format.h>
+#include <mutex>
 #include <map>
 
 /***********************************************************************
  * Global map structure for comparisons
  **********************************************************************/
-static Poco::RWLock &getMapMutex(void)
+static Pothos::Util::SpinLockRW &getMapMutex(void)
 {
-    static Poco::SingletonHolder<Poco::RWLock> sh;
-    return *sh.get();
+    static Pothos::Util::SpinLockRW lock;
+    return lock;
 }
 
 //singleton global map for all supported comparisons
 typedef std::map<size_t, Pothos::Plugin> HashFcnMapType;
 static HashFcnMapType &getHashFcnMap(void)
 {
-    static Poco::SingletonHolder<HashFcnMapType> sh;
-    return *sh.get();
+    static HashFcnMapType map;
+    return map;
 }
 
 /***********************************************************************
@@ -42,7 +42,7 @@ static void handleHashFcnPluginEvent(const Pothos::Plugin &plugin, const std::st
         if (call.type(-1) != typeid(size_t)) return;
         if (call.getNumArgs() != 1) return;
 
-        Poco::RWLock::ScopedWriteLock lock(getMapMutex());
+        std::lock_guard<Pothos::Util::SpinLockRW> lock(getMapMutex());
         if (event == "add")
         {
             getHashFcnMap()[call.type(0).hash_code()] = plugin;
@@ -73,7 +73,7 @@ pothos_static_block(pothosObjectHashFcnRegister)
 size_t Pothos::Object::hashCode(void) const
 {
     //find the plugin in the map, it will be null if not found
-    Poco::RWLock::ScopedReadLock lock(getMapMutex());
+    Pothos::Util::SpinLockRW::SharedLock lock(getMapMutex());
     auto it = getHashFcnMap().find(this->type().hash_code());
 
     //return the address when no hash function found

--- a/lib/Plugin/Module.cpp
+++ b/lib/Plugin/Module.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2016 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/System/Paths.hpp>
@@ -11,7 +11,6 @@
 #include <Poco/Logger.h>
 #include <Poco/Format.h>
 #include <mutex>
-#include <Poco/SingletonHolder.h>
 
 /***********************************************************************
  * Disabler for windows error messages
@@ -52,8 +51,8 @@ std::vector<std::string> getPluginPaths(const Pothos::PluginModule &module);
 
 static std::mutex &getModuleMutex(void)
 {
-    static Poco::SingletonHolder<std::mutex> sh;
-    return *sh.get();
+    static std::mutex mutex;
+    return mutex;
 }
 
 /***********************************************************************

--- a/lib/Plugin/ModuleSafeLoad.cpp
+++ b/lib/Plugin/ModuleSafeLoad.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2015 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/System/Paths.hpp>
@@ -11,7 +11,6 @@
 #include <Poco/Path.h>
 #include <Poco/AutoPtr.h>
 #include <Poco/Util/PropertyFileConfiguration.h>
-#include <Poco/SingletonHolder.h>
 #include <mutex>
 #include <cctype>
 
@@ -35,14 +34,14 @@ struct LoaderCacheFileLock : public Pothos::Util::FileLock
 
 static Pothos::Util::FileLock &getLoaderFileLock(void)
 {
-    static Poco::SingletonHolder<LoaderCacheFileLock> sh;
-    return *sh.get();
+    static LoaderCacheFileLock lock;
+    return lock;
 }
 
 static std::mutex &getLoaderMutex(void)
 {
-    static Poco::SingletonHolder<std::mutex> sh;
-    return *sh.get();
+    static std::mutex mutex;
+    return mutex;
 }
 
 /***********************************************************************

--- a/lib/Remote/ServerHandler.cpp
+++ b/lib/Remote/ServerHandler.cpp
@@ -7,7 +7,7 @@
 #include <Pothos/Proxy.hpp>
 #include <Pothos/Remote/Handler.hpp>
 #include <Pothos/System/HostInfo.hpp>
-#include <Poco/SingletonHolder.h>
+#include <Poco/Exception.h>
 #include <Poco/Bugcheck.h>
 #include <iostream>
 #include <mutex>
@@ -18,15 +18,15 @@
  **********************************************************************/
 static std::mutex &getObjectsMutex(void)
 {
-    static Poco::SingletonHolder<std::mutex> sh;
-    return *sh.get();
+    static std::mutex mutex;
+    return mutex;
 }
 
 typedef std::map<size_t, Pothos::Object> ServerObjectsMapType;
 static ServerObjectsMapType &getObjectsMap(void)
 {
-    static Poco::SingletonHolder<ServerObjectsMapType> sh;
-    return *sh.get();
+    static ServerObjectsMapType map;
+    return map;
 }
 
 static Pothos::Object getNewObjectId(const Pothos::Object &obj)

--- a/lib/System/Logger.cpp
+++ b/lib/System/Logger.cpp
@@ -20,7 +20,6 @@
 #include <Poco/Net/RemoteSyslogChannel.h>
 #include <Poco/Net/RemoteSyslogListener.h>
 #include <Poco/Net/DatagramSocket.h>
-#include <Poco/SingletonHolder.h>
 #include <Poco/String.h>
 #include <Poco/AutoPtr.h>
 #include <Poco/URI.h>
@@ -34,8 +33,8 @@
  **********************************************************************/
 static std::mutex &getSetupLoggerMutex(void)
 {
-    static Poco::SingletonHolder<std::mutex> sh;
-    return *sh.get();
+    static std::mutex mutex;
+    return mutex;
 }
 
 /***********************************************************************

--- a/lib/Testing.cpp
+++ b/lib/Testing.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2016 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Testing.hpp>
@@ -6,14 +6,13 @@
 #include <Poco/Path.h>
 #include <Poco/Format.h>
 #include <mutex>
-#include <Poco/SingletonHolder.h>
 #include <vector>
 #include <cassert>
 
 static std::mutex &getTestMutex(void)
 {
-    static Poco::SingletonHolder<std::mutex> sh;
-    return *sh.get();
+    static std::mutex mutex;
+    return mutex;
 }
 
 Pothos::TestingBase::TestingBase(void)


### PR DESCRIPTION
The goal is to speed up instances where we did one time initialization and then just read operations at main runtime. Using locks to protect these seldom written resources was wasteful and costly. So they are getting a read-write spin lock which is basically transparent as long as we are reading only.

Similarly, we removed poco singleton holder in a few places because it was causing unnecessary locking and should not be required because of the c++11 standard.

* Remove uses of poco singleton holder, should not be needed under c++11
* Added Pothos::Util::SpinLockRW for single write, multi-read 