### PR TITLE
msvc 2017 compiler updates

### DIFF
--- a/lib/Util/Builtin/MsvcCompilerSupport.in.cpp
+++ b/lib/Util/Builtin/MsvcCompilerSupport.in.cpp
@@ -25,11 +25,26 @@ public:
     {
         Poco::Path path("@MSVC_INSTALL_PATH@");
         std::vector<std::string> files; Poco::File(path).list(files);
+
+        #if _MSC_VER >= 1910 //2017 and up
+        _vcvars_arch = path.getFileName();
+        for (size_t i = 0; i < 8; i++)
+        {
+            if (path.getFileName() == "VC") break;
+            path = path.makeParent().makeFile();
+        }
+        if (path.getFileName() != "VC") return;
+        path = path.append("Auxiliary");
+        path = path.append("Build");
+        path = path.append("vcvarsall.bat");
+        _vcvars_path = path.toString();
+        #else
         for (size_t i = 0; i < files.size(); i++)
         {
             if (files[i].find("vcvars") != 0) continue; //expecting vcvarsxx.bat
             _vcvars_path = Poco::Path(path, files[i]).absolute().toString();
         }
+        #endif
     }
 
     bool test(void)
@@ -41,6 +56,7 @@ public:
 
 private:
     std::string _vcvars_path;
+    std::string _vcvars_arch;
 };
 
 std::string MsvcCompilerSupport::compileCppModule(const Pothos::Util::CompilerArgs &compilerArgs)
@@ -48,7 +64,7 @@ std::string MsvcCompilerSupport::compileCppModule(const Pothos::Util::CompilerAr
     //create compiler bat script
     const auto clBatPath = this->createTempFile(".bat");
     std::ofstream clBatFile(clBatPath.c_str());
-    clBatFile << "call \"" << _vcvars_path << "\"" << std::endl;
+    clBatFile << "call \"" << _vcvars_path << "\"" << " " << _vcvars_arch << std::endl;
     clBatFile << "cl.exe %*" << std::endl;
     clBatFile << "exit /b %ERRORLEVEL%" << std::endl;
     clBatFile.close();


### PR DESCRIPTION
2017 compiles and runs fine, but there are some layout differences for vcvars. This affects the JIT compilation support. Working on a fix in this branch that operates on 2017 and 2015. Presently the compilers do not like to both be installed at the same time.