### PR TITLE
Refactor RingDeque to work like stl container

### DIFF
--- a/include/Pothos/Framework/InputPortImpl.hpp
+++ b/include/Pothos/Framework/InputPortImpl.hpp
@@ -128,7 +128,7 @@ inline Pothos::Object Pothos::InputPort::asyncMessagesPop(void)
 {
     std::lock_guard<Util::SpinLock> lock(_asyncMessagesLock);
     if (_asyncMessages.empty()) return Pothos::Object();
-    auto msg = _asyncMessages.front().first;
+    auto msg = std::move(_asyncMessages.front().first);
     _asyncMessages.pop_front();
     return msg;
 }

--- a/include/Pothos/Util/RingDeque.hpp
+++ b/include/Pothos/Util/RingDeque.hpp
@@ -4,7 +4,7 @@
 /// A templated double ended queue implemented on top of a vector.
 ///
 /// \copyright
-/// Copyright (c) 2013-2016 Josh Blum
+/// Copyright (c) 2013-2017 Josh Blum
 /// SPDX-License-Identifier: BSL-1.0
 ///
 
@@ -12,7 +12,7 @@
 #include <Pothos/Config.hpp>
 #include <cstdlib> //size_t
 #include <utility> //forward
-#include <vector>
+#include <memory> //allocator
 #include <cassert>
 
 namespace Pothos {
@@ -25,15 +25,31 @@ namespace Util {
  * boost::circular_buffer without the boost requirement.
  * The ring deque does not have a specific capacity limit.
  */
-template <typename T>
+template <typename T, typename Allocator = std::allocator<T>>
 class RingDeque
 {
 public:
-    //! Construct a new ring deque
-    RingDeque(void);
+    /*!
+     * Construct a new ring deque
+     * \param capacity the maximum space available
+     * \param allocator an optional custom allocator
+     */
+    RingDeque(const size_t capacity = 1, const Allocator &allocator = Allocator());
 
-    //! Construct a new ring deque -- with space reservation
-    RingDeque(const size_t capacity);
+    //! Copy constructor
+    RingDeque(const RingDeque<T, Allocator> &other);
+
+    //! Move constructor
+    RingDeque(RingDeque<T, Allocator> &&other);
+
+    //! Copy assignment
+    RingDeque &operator=(const RingDeque<T, Allocator> &other);
+
+    //! Move assignment
+    RingDeque &operator=(RingDeque<T, Allocator> &&other);
+
+    //! Destruct the ring queue and any elements held
+    ~RingDeque(void);
 
     //! Get a const ref at, where front == 0, back == size() - 1
     const T &operator[](const size_t offset) const;
@@ -93,179 +109,240 @@ public:
     //! Empty the contents of this queue
     void clear(void);
 
+    typedef T value_type; //!< The element type
+
+    typedef Allocator allocator_type; //!< The allocator type
+
 private:
+    Allocator _allocator;
     size_t _frontIndex;
     size_t _backIndex;
     size_t _numElements;
-    std::vector<T> _container;
+    size_t _capacity;
+    T *_container;
 };
 
-template <typename T>
-RingDeque<T>::RingDeque(void):
-    _frontIndex(0),
-    _backIndex(0),
-    _numElements(0),
-    _container(1)
-{
-    return;
-}
-
-template <typename T>
-RingDeque<T>::RingDeque(const size_t capacity):
+template <typename T, typename A>
+RingDeque<T, A>::RingDeque(const size_t capacity, const A &allocator):
+    _allocator(allocator),
     _frontIndex(0),
     _backIndex(capacity-1),
     _numElements(0),
-    _container(capacity)
+    _capacity(capacity),
+    _container(_allocator.allocate(_capacity))
 {
     assert(capacity > 0);
 }
 
-template <typename T>
-const T &RingDeque<T>::operator[](const size_t offset) const
+template <typename T, typename A>
+RingDeque<T, A>::RingDeque(const RingDeque<T, A> &other):
+    _frontIndex(0),
+    _backIndex(other.capacity()-1),
+    _numElements(0),
+    _capacity(other.capacity()),
+    _container(_allocator.allocate(_capacity))
 {
-    return _container[(_frontIndex + offset) % _container.size()];
+    for (size_t i = 0; i < other.size(); i++)
+    {
+        this->push_back(other[i]);
+    }
 }
 
-template <typename T>
-T &RingDeque<T>::operator[](const size_t offset)
+template <typename T, typename A>
+RingDeque<T, A>::RingDeque(RingDeque<T, A> &&other):
+    _allocator(std::move(other._allocator)),
+    _frontIndex(std::move(other._frontIndex)),
+    _backIndex(std::move(other._backIndex)),
+    _numElements(std::move(other._numElements)),
+    _capacity(std::move(other._capacity)),
+    _container(std::move(other._container))
 {
-    return _container[(_frontIndex + offset) % _container.size()];
+    other._numElements = 0;
+    other._capacity = 0;
+    other._container = nullptr;
 }
 
-template <typename T>
+template <typename T, typename A>
+RingDeque<T, A> &RingDeque<T, A>::operator=(const RingDeque<T, A> &other)
+{
+    this->clear();
+    this->set_capacity(other.capacity());
+    for (size_t i = 0; i < other.size(); i++)
+    {
+        this->push_back(other[i]);
+    }
+    return *this;
+}
+
+template <typename T, typename A>
+RingDeque<T, A> &RingDeque<T, A>::operator=(RingDeque<T, A> &&other)
+{
+    this->clear();
+    _allocator.deallocate(_container, _capacity);
+    _allocator = std::move(other._allocator);
+    _frontIndex = std::move(other._frontIndex);
+    _backIndex = std::move(other._backIndex);
+    _numElements = std::move(other._numElements);
+    _capacity = std::move(other._capacity);
+    _container = std::move(other._container);
+    other._numElements = 0;
+    other._capacity = 0;
+    other._container = nullptr;
+    return *this;
+}
+
+template <typename T, typename A>
+RingDeque<T, A>::~RingDeque(void)
+{
+    if (_container == nullptr) return;
+    this->clear();
+    _allocator.deallocate(_container, _capacity);
+}
+
+template <typename T, typename A>
+const T &RingDeque<T, A>::operator[](const size_t offset) const
+{
+    return _container[(_frontIndex + offset) % _capacity];
+}
+
+template <typename T, typename A>
+T &RingDeque<T, A>::operator[](const size_t offset)
+{
+    return _container[(_frontIndex + offset) % _capacity];
+}
+
+template <typename T, typename A>
 template <typename U>
-void RingDeque<T>::push_front(U &&elem)
+void RingDeque<T, A>::push_front(U &&elem)
 {
-    assert(not this->full());
-    _frontIndex = size_t(_frontIndex + _container.size() - 1) % _container.size();
-    _container[_frontIndex] = std::forward<U>(elem);
-    _numElements++;
+    this->emplace_front(std::forward<U>(elem));
 }
 
-template <typename T>
+template <typename T, typename A>
 template <typename... Args>
-T &RingDeque<T>::emplace_front(Args&&... args)
+T &RingDeque<T, A>::emplace_front(Args&&... args)
 {
     assert(not this->full());
-    _frontIndex = size_t(_frontIndex + _container.size() - 1) % _container.size();
-    _container[_frontIndex] = T(std::forward<Args>(args)...);
+    _frontIndex = size_t(_frontIndex + _capacity - 1) % _capacity;
+    new (_container + _frontIndex) T(std::forward<Args>(args)...);
     _numElements++;
     return _container[_frontIndex];
 }
 
-template <typename T>
-void RingDeque<T>::pop_front(void)
+template <typename T, typename A>
+void RingDeque<T, A>::pop_front(void)
 {
     assert(not this->empty());
-    assert(_frontIndex < _container.size());
-    _container[_frontIndex] = T();
-    _frontIndex = size_t(_frontIndex + 1) % _container.size();
+    assert(_frontIndex < _capacity);
+    _container[_frontIndex].~T();
+    _frontIndex = size_t(_frontIndex + 1) % _capacity;
     _numElements--;
 }
 
-template <typename T>
-const T &RingDeque<T>::front(void) const
+template <typename T, typename A>
+const T &RingDeque<T, A>::front(void) const
 {
     assert(not this->empty());
-    assert(_frontIndex < _container.size());
+    assert(_frontIndex < _capacity);
     return _container[_frontIndex];
 }
 
-template <typename T>
-T &RingDeque<T>::front(void)
+template <typename T, typename A>
+T &RingDeque<T, A>::front(void)
 {
     assert(not this->empty());
-    assert(_frontIndex < _container.size());
+    assert(_frontIndex < _capacity);
     return _container[_frontIndex];
 }
 
-template <typename T>
+template <typename T, typename A>
 template <typename U>
-void RingDeque<T>::push_back(U &&elem)
+void RingDeque<T, A>::push_back(U &&elem)
 {
-    assert(not this->full());
-    _backIndex = size_t(_backIndex + 1) % _container.size();
-    _container[_backIndex] = std::forward<U>(elem);
-    _numElements++;
+    this->emplace_back(std::forward<U>(elem));
 }
 
-template <typename T>
+template <typename T, typename A>
 template <typename... Args>
-T &RingDeque<T>::emplace_back(Args&&... args)
+T &RingDeque<T, A>::emplace_back(Args&&... args)
 {
     assert(not this->full());
-    _backIndex = size_t(_backIndex + 1) % _container.size();
-    _container[_backIndex] = T(std::forward<Args>(args)...);
+    _backIndex = size_t(_backIndex + 1) % _capacity;
+    new (_container + _backIndex) T(std::forward<Args>(args)...);
     _numElements++;
     return _container[_backIndex];
 }
 
-template <typename T>
-void RingDeque<T>::pop_back(void)
+template <typename T, typename A>
+void RingDeque<T, A>::pop_back(void)
 {
     assert(not this->empty());
-    assert(_backIndex < _container.size());
-    _container[_backIndex] = T();
-    _backIndex = size_t(_backIndex + _container.size() - 1) % _container.size();
+    assert(_backIndex < _capacity);
+    _container[_backIndex].~T();
+    _backIndex = size_t(_backIndex + _capacity - 1) % _capacity;
     _numElements--;
 }
 
-template <typename T>
-const T &RingDeque<T>::back(void) const
+template <typename T, typename A>
+const T &RingDeque<T, A>::back(void) const
 {
     assert(not this->empty());
-    assert(_backIndex < _container.size());
+    assert(_backIndex < _capacity);
     return _container[_backIndex];
 }
 
-template <typename T>
-T &RingDeque<T>::back(void)
+template <typename T, typename A>
+T &RingDeque<T, A>::back(void)
 {
     assert(not this->empty());
-    assert(_backIndex < _container.size());
+    assert(_backIndex < _capacity);
     return _container[_backIndex];
 }
 
-template <typename T>
-bool RingDeque<T>::empty(void) const
+template <typename T, typename A>
+bool RingDeque<T, A>::empty(void) const
 {
     return _numElements == 0;
 }
 
-template <typename T>
-bool RingDeque<T>::full(void) const
+template <typename T, typename A>
+bool RingDeque<T, A>::full(void) const
 {
-    return _numElements == _container.size();
+    return _numElements == _capacity;
 }
 
-template <typename T>
-size_t RingDeque<T>::size(void) const
+template <typename T, typename A>
+size_t RingDeque<T, A>::size(void) const
 {
     return _numElements;
 }
 
-template <typename T>
-size_t RingDeque<T>::capacity(void) const
+template <typename T, typename A>
+size_t RingDeque<T, A>::capacity(void) const
 {
-    return _container.size();
+    return _capacity;
 }
 
-template <typename T>
-void RingDeque<T>::set_capacity(const size_t capacity)
+template <typename T, typename A>
+void RingDeque<T, A>::set_capacity(const size_t capacity)
 {
     if (_numElements > capacity) return;
-    std::vector<T> _newContainer(capacity);
+    T *newContainer = _allocator.allocate(capacity);
     for (size_t i = 0; i < _numElements; i++)
     {
-        _newContainer[i] = _container[(_frontIndex+i) % _container.size()];
+        T &elem = _container[(_frontIndex+i) % _capacity];
+        new (newContainer+i) T(std::move(elem));
+        elem.~T();
     }
-    _container = _newContainer;
+    _allocator.deallocate(_container, _capacity);
+    _container = newContainer;
+    _capacity = capacity;
     _frontIndex = 0;
     _backIndex = (_numElements + capacity - 1) % capacity;
 }
 
-template <typename T>
-void RingDeque<T>::clear(void)
+template <typename T, typename A>
+void RingDeque<T, A>::clear(void)
 {
     while (not this->empty())
     {

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -251,6 +251,7 @@ list(APPEND POTHOS_SOURCES
     Util/Builtin/DocUtils.cpp
     Util/Builtin/TestDocUtils.cpp
     Util/Builtin/TestEvalExpression.cpp
+    Util/Builtin/TestRingDeque.cpp
 
     Archive/ArchiveEntry.cpp
     Archive/StreamArchiver.cpp

--- a/lib/Framework/InputPort.cpp
+++ b/lib/Framework/InputPort.cpp
@@ -133,7 +133,7 @@ Pothos::Object Pothos::InputPort::slotCallsPop(void)
 {
     std::lock_guard<Util::SpinLock> lock(_slotCallsLock);
     assert(not _slotCalls.empty());
-    auto args = _slotCalls.front().first;
+    auto args = std::move(_slotCalls.front().first);
     _slotCalls.pop_front();
     return args;
 }
@@ -200,7 +200,7 @@ void Pothos::InputPort::bufferLabelPush(
         {
             auto label = byteOffsetLabel;
             label.index += currentBytes; //increment by enqueued bytes
-            _inputInlineMessages.push_back(label);
+            _inputInlineMessages.push_back(std::move(label));
         }
 
         //push all buffers into the accumulator

--- a/lib/Util/Builtin/TestRingDeque.cpp
+++ b/lib/Util/Builtin/TestRingDeque.cpp
@@ -1,0 +1,142 @@
+// Copyright (c) 2017-2017 Josh Blum
+// SPDX-License-Identifier: BSL-1.0
+
+#include <Pothos/Testing.hpp>
+#include <Pothos/Util/RingDeque.hpp>
+#include <string>
+#include <iostream>
+
+POTHOS_TEST_BLOCK("/util/tests", test_ring_deque)
+{
+    Pothos::Util::RingDeque<std::string> ring0;
+    POTHOS_TEST_EQUAL(ring0.capacity(), 1);
+    POTHOS_TEST_TRUE(ring0.empty());
+    POTHOS_TEST_TRUE(not ring0.full());
+
+    ring0.set_capacity(10);
+    POTHOS_TEST_EQUAL(ring0.capacity(), 10);
+    POTHOS_TEST_TRUE(ring0.empty());
+    POTHOS_TEST_TRUE(not ring0.full());
+
+    //fill with elements
+    for (size_t i = 0; i < 10; i++)
+    {
+        POTHOS_TEST_EQUAL(ring0.size(), i);
+        POTHOS_TEST_TRUE(not ring0.full());
+        ring0.push_back(std::to_string(i));
+        POTHOS_TEST_TRUE(not ring0.empty());
+    }
+    POTHOS_TEST_TRUE(ring0.full());
+    POTHOS_TEST_EQUAL(ring0.size(), 10);
+
+    //test indexing
+    for (size_t i = 0; i < 10; i++)
+    {
+        POTHOS_TEST_EQUAL(ring0[i], std::to_string(i));
+    }
+
+    //pop in order
+    for (size_t i = 0; i < 10; i++)
+    {
+        POTHOS_TEST_EQUAL(ring0.size(), 10-i);
+        POTHOS_TEST_TRUE(not ring0.empty());
+        POTHOS_TEST_EQUAL(ring0.front(), std::to_string(i));
+        ring0.pop_front();
+        POTHOS_TEST_TRUE(not ring0.full());
+    }
+    POTHOS_TEST_TRUE(ring0.empty());
+    POTHOS_TEST_EQUAL(ring0.size(), 0);
+
+    //fill with elements
+    for (size_t i = 0; i < 10; i++)
+    {
+        POTHOS_TEST_TRUE(not ring0.full());
+        ring0.push_back(std::to_string(i));
+        POTHOS_TEST_TRUE(not ring0.empty());
+    }
+    POTHOS_TEST_TRUE(ring0.full());
+
+    //pop in reverse
+    for (int i = 9; i >= 0; i--)
+    {
+        POTHOS_TEST_EQUAL(ring0.size(), size_t(i+1));
+        POTHOS_TEST_TRUE(not ring0.empty());
+        POTHOS_TEST_EQUAL(ring0.back(), std::to_string(i));
+        ring0.pop_back();
+        POTHOS_TEST_TRUE(not ring0.full());
+    }
+    POTHOS_TEST_TRUE(ring0.empty());
+    POTHOS_TEST_EQUAL(ring0.size(), 0);
+
+    //fill with elements
+    for (size_t i = 0; i < 10; i++)
+    {
+        POTHOS_TEST_EQUAL(ring0.size(), i);
+        POTHOS_TEST_TRUE(not ring0.full());
+        ring0.push_back(std::to_string(i));
+        POTHOS_TEST_TRUE(not ring0.empty());
+    }
+    POTHOS_TEST_TRUE(ring0.full());
+    POTHOS_TEST_EQUAL(ring0.size(), 10);
+
+    //change capacity
+    ring0.set_capacity(20);
+    POTHOS_TEST_EQUAL(ring0.capacity(), 20);
+    POTHOS_TEST_TRUE(not ring0.full());
+
+    //test indexing
+    for (size_t i = 0; i < 10; i++)
+    {
+        POTHOS_TEST_EQUAL(ring0[i], std::to_string(i));
+    }
+
+    ring0.clear();
+    POTHOS_TEST_EQUAL(ring0.size(), 0);
+    POTHOS_TEST_TRUE(ring0.empty());
+    POTHOS_TEST_TRUE(not ring0.full());
+}
+
+POTHOS_TEST_BLOCK("/util/tests", test_ring_deque_copy)
+{
+    Pothos::Util::RingDeque<std::string> ring0(10);
+    for (size_t i = 0; i < 10; i++)
+    {
+        ring0.push_back(std::to_string(i));
+    }
+
+    //test copy construct
+    Pothos::Util::RingDeque<std::string> ring1(ring0);
+    POTHOS_TEST_EQUAL(ring0.size(), ring1.size());
+    for (size_t i = 0; i < 10; i++)
+    {
+        POTHOS_TEST_EQUAL(ring0[i], ring1[i]);
+    }
+
+    //test copy assignment
+    Pothos::Util::RingDeque<std::string> ring2;
+    ring2 = ring1;
+    POTHOS_TEST_EQUAL(ring0.size(), ring2.size());
+    for (size_t i = 0; i < 10; i++)
+    {
+        POTHOS_TEST_EQUAL(ring0[i], ring2[i]);
+    }
+
+    //test move construct
+    Pothos::Util::RingDeque<std::string> ring3(std::move(ring2));
+    POTHOS_TEST_EQUAL(ring2.size(), 0);
+    POTHOS_TEST_EQUAL(ring0.size(), ring3.size());
+    for (size_t i = 0; i < 10; i++)
+    {
+        POTHOS_TEST_EQUAL(ring0[i], ring3[i]);
+    }
+
+    //test move assignment
+    Pothos::Util::RingDeque<std::string> ring4;
+    ring4 = std::move(ring3);
+    POTHOS_TEST_EQUAL(ring3.size(), 0);
+    POTHOS_TEST_EQUAL(ring0.size(), ring4.size());
+    for (size_t i = 0; i < 10; i++)
+    {
+        POTHOS_TEST_EQUAL(ring0[i], ring4[i]);
+    }
+}


### PR DESCRIPTION
Save copying overhead by replacing internal std::vector with memory provided by std::allocator. This saves on the overhead of copying into and popping from unused slots.

* std::allocator support for ring deque
* placement new for pushes
* explicit destruct for pops
* move/copy/construct/assign overloads
* unit test for ring deque
* misc use of move in Framework when applicable