### PR TITLE
Object container work

### DIFF
--- a/include/Pothos/Object/Object.hpp
+++ b/include/Pothos/Object/Object.hpp
@@ -9,17 +9,10 @@
 ///
 
 #pragma once
-//We need to declare lots of copy constructors so the templated version is only called explicitly.
-//However, the constructors cause the following warning on MSVC, which we disable below:
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning (disable:4521) // 'class' : multiple copy constructors specified
-#endif //_MSC_VER
-
 #include <Pothos/Config.hpp>
+#include <Pothos/Util/Templates.hpp>
 #include <typeinfo>
 #include <string>
-#include <iosfwd>
 
 namespace Pothos {
 
@@ -79,13 +72,6 @@ public:
     Object(const Object &obj);
 
     /*!
-     * Copy constructor for Object -- does not copy the internal data.
-     * Both obj and the resulting Object will point to the same data.
-     * \param obj another Object
-     */
-    Object(Object &obj);
-
-    /*!
      * Move constructor for Object.
      * The contents of obj will be moved to the new Object.
      * \param obj another Object
@@ -93,17 +79,10 @@ public:
     Object(Object &&obj);
 
     /*!
-     * Move constructor for Object.
-     * The contents of obj will be moved to the new Object.
-     * \param obj another Object
-     */
-    Object(const Object &&obj);
-
-    /*!
      * Create a new Object from an an arbitrary value.
      * \param value the data to store internally
      */
-    template <typename ValueType>
+    template <typename ValueType, typename = Pothos::Util::disable_if_same<Object, ValueType>>
     explicit Object(ValueType &&value);
 
     /*!
@@ -292,10 +271,6 @@ public:
 inline bool operator==(const Object &lhs, const Object &rhs);
 
 } //namespace Pothos
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif //_MSC_VER
 
 inline bool Pothos::operator==(const Object &lhs, const Object &rhs)
 {

--- a/include/Pothos/Object/ObjectImpl.hpp
+++ b/include/Pothos/Object/ObjectImpl.hpp
@@ -133,7 +133,7 @@ Object Object::make(ValueType &&value)
     return o;
 }
 
-template <typename ValueType>
+template <typename ValueType, typename>
 Object::Object(ValueType &&value):
     _impl(nullptr)
 {

--- a/include/Pothos/Util/Templates.hpp
+++ b/include/Pothos/Util/Templates.hpp
@@ -116,5 +116,13 @@ template<typename... T>
 using index_sequence_for = make_index_sequence<sizeof...(T)>;
 //! \}
 
+/*!*********************************************************************
+ * Disable SFINAE type used with universal reference constructors
+ * \see http://ericniebler.com/2013/08/07/universal-references-and-the-copy-constructo/
+ **********************************************************************/
+template<typename BaseType, typename OtherType>
+using disable_if_same = typename std::enable_if<
+    not std::is_same<BaseType, typename std::decay<OtherType>::type>::value>::type;
+
 } //namespace Util
 } //namespace Pothos

--- a/lib/Object/Object.cpp
+++ b/lib/Object/Object.cpp
@@ -76,19 +76,7 @@ Pothos::Object::Object(const Object &obj):
     *this = obj;
 }
 
-Pothos::Object::Object(Object &obj):
-    _impl(nullptr)
-{
-    *this = obj;
-}
-
 Pothos::Object::Object(Object &&obj):
-    _impl(nullptr)
-{
-    *this = obj;
-}
-
-Pothos::Object::Object(const Object &&obj):
     _impl(nullptr)
 {
     *this = obj;

--- a/lib/Object/Object.cpp
+++ b/lib/Object/Object.cpp
@@ -71,15 +71,15 @@ Pothos::Object::Object(void):
 }
 
 Pothos::Object::Object(const Object &obj):
-    _impl(nullptr)
+    _impl(obj._impl)
 {
-    *this = obj;
+    incr(_impl);
 }
 
 Pothos::Object::Object(Object &&obj):
-    _impl(nullptr)
+    _impl(obj._impl)
 {
-    *this = obj;
+    obj._impl = nullptr;
 }
 
 Pothos::Object::~Object(void)


### PR DESCRIPTION
Additional clean-up with Disable SFINAE type used with universal reference constructors. See http://ericniebler.com/2013/08/07/universal-references-and-the-copy-constructo/

* Removed redundant calls to constructor to force overload resolution. This is a standard pattern with universal references that can be handled with SFINAE
* Added template for disable_if_same, unlike the article above we don't have a derived object class so is_same will work, do not need is_base
* Cleans up MSVC pragma warnings for these redundant/removed calls, now not needed
* Implement Object copy/move constructors directly without re-using assignment operators