### PR TITLE
Block resource moves

### DIFF
--- a/include/Pothos/Framework/Block.hpp
+++ b/include/Pothos/Framework/Block.hpp
@@ -349,8 +349,8 @@ private:
     std::multimap<std::string, Callable> _calls;
     std::map<std::string, std::pair<std::string, std::string>> _probes;
     ThreadPool _threadPool;
-    Block(const Block &){} // non construction-copyable
-    Block &operator=(const Block &){return *this;} // non copyable
+    Block(const Block &) = delete; // non construction-copyable
+    Block &operator=(const Block &) = delete; // non copyable
 public:
     std::shared_ptr<WorkerActor> _actor;
     friend class WorkerActor;

--- a/include/Pothos/Framework/BufferChunk.hpp
+++ b/include/Pothos/Framework/BufferChunk.hpp
@@ -5,7 +5,7 @@
 /// a managed or shared buffer and address/length offsets.
 ///
 /// \copyright
-/// Copyright (c) 2013-2016 Josh Blum
+/// Copyright (c) 2013-2017 Josh Blum
 /// SPDX-License-Identifier: BSL-1.0
 ///
 
@@ -139,11 +139,27 @@ public:
     size_t getEnd(void) const;
 
     /*!
-     * Get a pointer to the front of the buffer
-     * casted to the desired data type.
+     * Get a pointer to the front of the buffer as the specified data type.
+     * \code
+     * auto ptr = buffer.as<const int *>();
+     * \endcode
+     * \tparam ElementType the desired pointer type
+     * \return the front of the buffer casted into the specified pointer type
      */
     template <typename ElementType>
     ElementType as(void) const;
+
+    /*!
+     * Get a pointer to the front of the buffer as the specified data type.
+     * This call overloads the conversion operator to provide implicit conversion.
+     * \code
+     * const int *ptr = buffer;
+     * \endcode
+     * \return the front of the buffer casted into the specified pointer type
+     * \tparam ElementType the desired pointer type
+     */
+    template <typename ElementType>
+    operator ElementType(void) const;
 
     /*!
      * Is the reference to the shared buffer unique?
@@ -392,6 +408,12 @@ inline size_t Pothos::BufferChunk::getEnd(void) const
 
 template <typename ElementType>
 ElementType Pothos::BufferChunk::as(void) const
+{
+    return reinterpret_cast<ElementType>(address);
+}
+
+template <typename ElementType>
+Pothos::BufferChunk::operator ElementType(void) const
 {
     return reinterpret_cast<ElementType>(address);
 }

--- a/include/Pothos/Framework/InputPort.hpp
+++ b/include/Pothos/Framework/InputPort.hpp
@@ -249,15 +249,16 @@ private:
     /////// input buffer interface /////////
     void bufferAccumulatorFront(BufferChunk &);
     void bufferAccumulatorPush(const BufferChunk &buffer);
-    void bufferAccumulatorPushNoLock(const BufferChunk &buffer);
+    void bufferAccumulatorPushNoLock(BufferChunk &&buffer);
     void bufferAccumulatorPop(const size_t numBytes);
     void bufferAccumulatorRequire(const size_t numBytes);
     void bufferAccumulatorClear(void);
 
     /////// combined label association push /////////
     void bufferLabelPush(
-        const std::vector<Label> &postedLabels,
-        const Util::RingDeque<BufferChunk> &postedBuffers);
+        const bool enableMove,
+        std::vector<Label> &postedLabels,
+        Util::RingDeque<BufferChunk> &postedBuffers);
 
     InputPort(void);
     InputPort(const InputPort &){} // non construction-copyable

--- a/include/Pothos/Framework/InputPort.hpp
+++ b/include/Pothos/Framework/InputPort.hpp
@@ -276,8 +276,8 @@ private:
         Util::RingDeque<BufferChunk> &postedBuffers);
 
     InputPort(void);
-    InputPort(const InputPort &){} // non construction-copyable
-    InputPort &operator=(const InputPort &){return *this;} // non copyable
+    InputPort(const InputPort &) = delete; // non construction-copyable
+    InputPort &operator=(const InputPort &) = delete; // non copyable
     friend class WorkerActor;
     friend class OutputPort;
 };

--- a/include/Pothos/Framework/InputPort.hpp
+++ b/include/Pothos/Framework/InputPort.hpp
@@ -4,7 +4,7 @@
 /// This file provides an interface for a worker's input port.
 ///
 /// \copyright
-/// Copyright (c) 2014-2016 Josh Blum
+/// Copyright (c) 2014-2017 Josh Blum
 /// SPDX-License-Identifier: BSL-1.0
 ///
 
@@ -123,6 +123,21 @@ public:
      * \param numElements the number of elements to consume
      */
     void consume(const size_t numElements);
+
+    /*!
+     * Take buffer transfers ownership of the buffer to the caller.
+     * Use takeBuffer() to support perfect buffer forwarding
+     * with postBuffer() and postMessage() on an output port.
+     * \code
+     * auto buff = inPort->takeBuffer();
+     * outPort->postBuffer(std::move(buff));
+     * \endcode
+     * \note Note that takeBuffer() does not consume. The caller must also call
+     * consume() with the number of elements actually read from the buffer.
+     * \post buffer() has undefined behavior after this call.
+     * \return the buffer from this input port
+     */
+    BufferChunk takeBuffer(void);
 
     /*!
      * Remove and return an asynchronous message from the port.

--- a/include/Pothos/Framework/InputPortImpl.hpp
+++ b/include/Pothos/Framework/InputPortImpl.hpp
@@ -4,7 +4,7 @@
 /// Inline member implementation for InputPort class.
 ///
 /// \copyright
-/// Copyright (c) 2014-2016 Josh Blum
+/// Copyright (c) 2014-2017 Josh Blum
 /// SPDX-License-Identifier: BSL-1.0
 ///
 
@@ -70,6 +70,11 @@ inline const Pothos::LabelIteratorRange &Pothos::InputPort::labels(void) const
 inline void Pothos::InputPort::consume(const size_t numElements)
 {
     _pendingElements += numElements;
+}
+
+inline Pothos::BufferChunk Pothos::InputPort::takeBuffer(void)
+{
+    return std::move(_buffer);
 }
 
 inline bool Pothos::InputPort::hasMessage(void)

--- a/include/Pothos/Framework/InputPortImpl.hpp
+++ b/include/Pothos/Framework/InputPortImpl.hpp
@@ -159,8 +159,8 @@ inline void Pothos::InputPort::bufferAccumulatorFront(Pothos::BufferChunk &buff)
     std::lock_guard<Util::SpinLock> lock(_bufferAccumulatorLock);
     while (not _inputInlineMessages.empty())
     {
-        const auto &front = _inputInlineMessages.front();
-        _inlineMessages.push_back(front.toAdjusted(1, this->dtype().size()));
+        _inlineMessages.push_back(std::move(_inputInlineMessages.front()));
+        _inlineMessages.back().adjust(1, this->dtype().size());
         _inputInlineMessages.pop_front();
     }
     buff = _bufferAccumulator.front();

--- a/include/Pothos/Framework/InputPortImpl.hpp
+++ b/include/Pothos/Framework/InputPortImpl.hpp
@@ -169,7 +169,7 @@ inline void Pothos::InputPort::bufferAccumulatorFront(Pothos::BufferChunk &buff)
 inline void Pothos::InputPort::bufferAccumulatorPush(const BufferChunk &buffer)
 {
     std::lock_guard<Util::SpinLock> lock(_bufferAccumulatorLock);
-    this->bufferAccumulatorPushNoLock(buffer);
+    this->bufferAccumulatorPushNoLock(BufferChunk(buffer));
 }
 
 inline void Pothos::InputPort::bufferAccumulatorRequire(const size_t numBytes)

--- a/include/Pothos/Framework/Label.hpp
+++ b/include/Pothos/Framework/Label.hpp
@@ -42,6 +42,15 @@ public:
     Label toAdjusted(const MultType &mult, const DivType &div) const;
 
     /*!
+     * Adjust the index and width based on a multiplier/divider.
+     * \param mult a positive multiplier (default 1)
+     * \param div a positive divider (default 1)
+     * \return a reference to this label
+     */
+    template <typename MultType, typename DivType>
+    Label &adjust(const MultType &mult, const DivType &div);
+
+    /*!
      * The identifier describes the label's type, meaning, or purpose.
      * Identifiers only have meaning in the context of the blocks
      * that are producing and consuming them. So any given pair of blocks
@@ -127,12 +136,19 @@ Pothos::Label::Label(const std::string &id, ValueType &&data, const unsigned lon
 template <typename MultType, typename DivType>
 Pothos::Label Pothos::Label::toAdjusted(const MultType &mult, const DivType &div) const
 {
-    Pothos::Label newLabel = *this;
-    newLabel.index *= mult;
-    newLabel.width *= mult;
-    newLabel.index /= div;
-    newLabel.width /= div;
+    Pothos::Label newLabel(*this);
+    newLabel.adjust(mult, div);
     return newLabel;
+}
+
+template <typename MultType, typename DivType>
+Pothos::Label &Pothos::Label::adjust(const MultType &mult, const DivType &div)
+{
+    this->index *= mult;
+    this->width *= mult;
+    this->index /= div;
+    this->width /= div;
+    return *this;
 }
 
 inline bool Pothos::operator==(const Label &rhs, const Label &lhs)

--- a/include/Pothos/Framework/OutputPort.hpp
+++ b/include/Pothos/Framework/OutputPort.hpp
@@ -254,8 +254,8 @@ private:
     BufferPool _bufferPool;
 
     OutputPort(void);
-    OutputPort(const OutputPort &){} // non construction-copyable
-    OutputPort &operator=(const OutputPort &){return *this;} // non copyable
+    OutputPort(const OutputPort &) = delete; // non construction-copyable
+    OutputPort &operator=(const OutputPort &) = delete; // non copyable
     friend class WorkerActor;
     friend class InputPort;
     void _postMessage(const Object &message);

--- a/include/Pothos/Framework/OutputPort.hpp
+++ b/include/Pothos/Framework/OutputPort.hpp
@@ -122,6 +122,7 @@ public:
      * for use with postBuffer() and postMessage() calls.
      * The call will attempt to use the front buffer from
      * this output port and will fall-back to a reusable pool.
+     * \post buffer() has undefined behavior after this call.
      * \param numElements the minimum buffer size
      * \return a buffer chunk with at least numElements
      */

--- a/include/Pothos/Framework/OutputPort.hpp
+++ b/include/Pothos/Framework/OutputPort.hpp
@@ -129,10 +129,16 @@ public:
 
     /*!
      * Post an output label to the subscribers on this port.
+     * postLabel also supports move and emplacement semantics.
+     * \code
+     * port->postLabel(label);
+     * port->postLabel(std::move(label));
+     * port->postLabel(id, data, index);
+     * \endcode
      * \param label the label to post
      */
-    template <typename ValueType>
-    void postLabel(ValueType &&label);
+    template <typename... ValueType>
+    void postLabel(ValueType&&... label);
 
     /*!
      * Post an output message to the subscribers on this port.

--- a/include/Pothos/Framework/OutputPort.hpp
+++ b/include/Pothos/Framework/OutputPort.hpp
@@ -4,7 +4,7 @@
 /// This file provides an interface for a worker's output port.
 ///
 /// \copyright
-/// Copyright (c) 2014-2016 Josh Blum
+/// Copyright (c) 2014-2017 Josh Blum
 /// SPDX-License-Identifier: BSL-1.0
 ///
 
@@ -131,7 +131,8 @@ public:
      * Post an output label to the subscribers on this port.
      * \param label the label to post
      */
-    void postLabel(const Label &label);
+    template <typename ValueType>
+    void postLabel(ValueType &&label);
 
     /*!
      * Post an output message to the subscribers on this port.
@@ -149,7 +150,8 @@ public:
      * Do not call produce() when using postBuffer().
      * \param buffer the buffer to post
      */
-    void postBuffer(const BufferChunk &buffer);
+    template <typename ValueType>
+    void postBuffer(ValueType &&buffer);
 
     /*!
      * Set a reserve requirement on this output port.

--- a/include/Pothos/Framework/OutputPortImpl.hpp
+++ b/include/Pothos/Framework/OutputPortImpl.hpp
@@ -99,6 +99,7 @@ inline void Pothos::OutputPort::postBuffer(ValueType &&buffer)
     //unspecified buffer dtype? copy it from the port
     if (not r.dtype) r.dtype = this->dtype();
 
+    _totalElements += r.elements();
     _totalBuffers++;
     _workEvents++;
 }

--- a/include/Pothos/Framework/OutputPortImpl.hpp
+++ b/include/Pothos/Framework/OutputPortImpl.hpp
@@ -104,10 +104,10 @@ inline void Pothos::OutputPort::postBuffer(ValueType &&buffer)
     _workEvents++;
 }
 
-template <typename ValueType>
-inline void Pothos::OutputPort::postLabel(ValueType &&label)
+template <typename... ValueType>
+inline void Pothos::OutputPort::postLabel(ValueType&&... label)
 {
-    _postedLabels.push_back(std::forward<ValueType>(label));
+    _postedLabels.emplace_back(std::forward<ValueType>(label)...);
     _postedLabels.back().adjust(this->dtype().size(), 1);
     _totalLabels++;
     _workEvents++;

--- a/include/Pothos/Framework/OutputPortImpl.hpp
+++ b/include/Pothos/Framework/OutputPortImpl.hpp
@@ -89,22 +89,25 @@ inline void Pothos::OutputPort::popElements(const size_t numElements)
     _workEvents++;
 }
 
-inline void Pothos::OutputPort::postBuffer(const BufferChunk &buffer)
+template <typename ValueType>
+inline void Pothos::OutputPort::postBuffer(ValueType &&buffer)
 {
     auto &queue = _postedBuffers;
     if (queue.full()) queue.set_capacity(queue.size()*2);
-    queue.push_back(buffer);
+    auto &r = queue.emplace_back(std::forward<ValueType>(buffer));
 
     //unspecified buffer dtype? copy it from the port
-    if (not buffer.dtype) queue.back().dtype = this->dtype();
+    if (not r.dtype) r.dtype = this->dtype();
 
     _totalBuffers++;
     _workEvents++;
 }
 
-inline void Pothos::OutputPort::postLabel(const Label &label)
+template <typename ValueType>
+inline void Pothos::OutputPort::postLabel(ValueType &&label)
 {
-    _postedLabels.push_back(label.toAdjusted(this->dtype().size(), 1));
+    _postedLabels.push_back(std::forward<ValueType>(label));
+    _postedLabels.back().adjust(this->dtype().size(), 1);
     _totalLabels++;
     _workEvents++;
 }

--- a/lib/Framework/InputPort.cpp
+++ b/lib/Framework/InputPort.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Framework/InputPortImpl.hpp>
@@ -250,6 +250,7 @@ static auto managedInputPort = Pothos::ManagedClass()
     .registerMethod(POTHOS_FCN_TUPLE(Pothos::InputPort, labels))
     .registerMethod(POTHOS_FCN_TUPLE(Pothos::InputPort, removeLabel))
     .registerMethod(POTHOS_FCN_TUPLE(Pothos::InputPort, consume))
+    .registerMethod(POTHOS_FCN_TUPLE(Pothos::InputPort, takeBuffer))
     .registerMethod(POTHOS_FCN_TUPLE(Pothos::InputPort, popMessage))
     .registerMethod(POTHOS_FCN_TUPLE(Pothos::InputPort, peekMessage))
     .registerMethod(POTHOS_FCN_TUPLE(Pothos::InputPort, setReserve))

--- a/lib/Framework/Label.cpp
+++ b/lib/Framework/Label.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Framework/Label.hpp>
@@ -21,7 +21,8 @@ Pothos::LabelIteratorRange::LabelIteratorRange(void):
 static auto managedLabel = Pothos::ManagedClass()
     .registerConstructor<Pothos::Label>()
     .registerConstructor<Pothos::Label, const std::string &, const Pothos::Object &, const unsigned long long>()
-    .registerMethod("toAdjusted", Pothos::Callable::make(&Pothos::Label::toAdjusted<double, double>))
+    .registerMethod("toAdjusted", &Pothos::Label::toAdjusted<double, double>)
+    .registerMethod("adjust", &Pothos::Label::adjust<double, double>)
     .registerField(POTHOS_FCN_TUPLE(Pothos::Label, id))
     .registerField(POTHOS_FCN_TUPLE(Pothos::Label, data))
     .registerField(POTHOS_FCN_TUPLE(Pothos::Label, index))

--- a/lib/Framework/OutputPort.cpp
+++ b/lib/Framework/OutputPort.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Framework/OutputPortImpl.hpp>
@@ -43,7 +43,7 @@ Pothos::BufferChunk Pothos::OutputPort::getBuffer(const size_t numElements)
 {
     const size_t numBytes = numElements*_dtype.size();
 
-    //use the front buffer is possible
+    //use the front buffer if possible
     {
         std::lock_guard<Util::SpinLock> lock(_bufferManagerLock);
         Pothos::BufferChunk out(_bufferManager->front());
@@ -123,9 +123,9 @@ static auto managedOutputPort = Pothos::ManagedClass()
     .registerMethod(POTHOS_FCN_TUPLE(Pothos::OutputPort, produce))
     .registerMethod(POTHOS_FCN_TUPLE(Pothos::OutputPort, popElements))
     .registerMethod(POTHOS_FCN_TUPLE(Pothos::OutputPort, getBuffer))
-    .registerMethod(POTHOS_FCN_TUPLE(Pothos::OutputPort, postLabel))
+    .registerMethod("postLabel", &Pothos::OutputPort::postLabel<const Pothos::Label &>)
     .registerMethod("postMessage", &Pothos::OutputPort::postMessage<const Pothos::Object &>)
-    .registerMethod(POTHOS_FCN_TUPLE(Pothos::OutputPort, postBuffer))
+    .registerMethod("postBuffer", &Pothos::OutputPort::postBuffer<const Pothos::BufferChunk &>)
     .registerMethod(POTHOS_FCN_TUPLE(Pothos::OutputPort, setReserve))
     .registerMethod(POTHOS_FCN_TUPLE(Pothos::OutputPort, isSignal))
     .registerMethod(POTHOS_FCN_TUPLE(Pothos::OutputPort, setReadBeforeWrite))


### PR DESCRIPTION
* Added takeBuffer for InputPort to support perfect forwarding
* Support perfect forwarding for postBuffer and postLabel
* Implicit cast support for BufferChunk
* Move for buffers and labels on last subscriber
* Support mutating adjust() API for Label