### PR TITLE
Fixed bug were default constructor Pothos::PluginPath creating a shad…

### DIFF
--- a/lib/Util/BlockDescription.cpp
+++ b/lib/Util/BlockDescription.cpp
@@ -303,7 +303,7 @@ static json parseCommentBlockForMarkup(const CodeBlock &commentBlock)
         }
         else if (instruction == "alias" and state == "DOC")
         {
-            try {Pothos::PluginPath(payload);}
+            try {Pothos::PluginPath{payload};}
             catch (const Pothos::PluginPathError &)
             {
                 throw Pothos::SyntaxException("Invalid alias path", codeLine.toString());
@@ -433,7 +433,7 @@ static json parseCommentBlockForMarkup(const CodeBlock &commentBlock)
             const std::string argsStr(fields[2]);
 
             //add the path
-            try {Pothos::PluginPath(path);}
+            try {Pothos::PluginPath{path};}
             catch (const Pothos::PluginPathError &)
             {
                 throw Pothos::SyntaxException("Invalid factory path", codeLine.toString());


### PR DESCRIPTION
Subtle bug found during build

<pre>
pothos/lib/Util/BlockDescription.cpp: In function ‘json parseCommentBlockForMarkup(const CodeBlock&)’:
pothos/lib/Util/BlockDescription.cpp:306:36: warning: unnecessary parentheses in declaration of ‘payload’ [-Wparentheses]
             try {Pothos::PluginPath(payload);}
                                    ^
pothos/lib/Util/BlockDescription.cpp:306:44: warning: declaration of ‘payload’ shadows a previous local [-Wshadow]
             try {Pothos::PluginPath(payload);}
                                            ^
pothos/lib/Util/BlockDescription.cpp:247:17: note: shadowed declaration is here
     std::string payload;
                 ^~~~~~~
pothos/lib/Util/BlockDescription.cpp:436:36: warning: unnecessary parentheses in declaration of ‘path’ [-Wparentheses]
             try {Pothos::PluginPath(path);}
                                    ^
pothos/lib/Util/BlockDescription.cpp:436:41: warning: declaration of ‘path’ shadows a previous local [-Wshadow]
             try {Pothos::PluginPath(path);}
                                         ^
</pre>

Also I noticed  https://github.com/pothosware/PothosCore/blob/4bb5aad9bdafb0424750a021e84d4d29d87da473/include/Pothos/Plugin/Path.hpp#L30
 Not sure if this was to mitigate such problems, but far as I'm aware explicit on a default constructor has no effect.