### PR TITLE
Paths: added getPothosModulesPath() to get modules directory for current ABI

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3,6 +3,7 @@ This this the changelog file for the Pothos C++ library.
 Release 0.7.0 (pending)
 ==========================
 
+- Added function to query Pothos module search paths
 - Added std::function support for Callable API
 - Added calls setOut/InputAlias() for Topology API
 - Update poco submodule to poco-1.9.0-release

--- a/apps/PothosUtilSystemInfo.cpp
+++ b/apps/PothosUtilSystemInfo.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2013-2018 Josh Blum
+//                    2019 Nicholas Corgan
 // SPDX-License-Identifier: BSL-1.0
 
 #include "PothosUtil.hpp"
@@ -18,4 +19,9 @@ void PothosUtilBase::printSystemInfo(const std::string &, const std::string &)
     std::cout << "Util Executable: " << Pothos::System::getPothosUtilExecutablePath() << std::endl;
     std::cout << "Dev Include Path: " << Pothos::System::getPothosDevIncludePath() << std::endl;
     std::cout << "Dev Library Path: " << Pothos::System::getPothosDevLibraryPath() << std::endl;
+    std::cout << "Module Search Paths:" << std::endl;
+    for(const auto& searchPath: Pothos::System::getPothosModuleSearchPaths())
+    {
+        std::cout << " * " << searchPath << std::endl;
+    }
 }

--- a/include/Pothos/System/Paths.hpp
+++ b/include/Pothos/System/Paths.hpp
@@ -5,12 +5,14 @@
 ///
 /// \copyright
 /// Copyright (c) 2013-2014 Josh Blum
+///                    2019 Nicholas Corgan
 /// SPDX-License-Identifier: BSL-1.0
 ///
 
 #pragma once
 #include <Pothos/Config.hpp>
 #include <string>
+#include <vector>
 
 namespace Pothos {
 namespace System {
@@ -62,6 +64,12 @@ namespace System {
      * Get the full path to the development libraries directory.
      */
     POTHOS_API std::string getPothosDevLibraryPath(void);
+
+    /*!
+     * Get the list of paths Pothos searches to find modules for the current
+     * ABI.
+     */
+    POTHOS_API std::vector<std::string> getPothosModuleSearchPaths();
 
 } //namespace System
 } //namespace Pothos

--- a/lib/System/Paths.in.cpp
+++ b/lib/System/Paths.in.cpp
@@ -9,6 +9,7 @@
 #include <Poco/Foundation.h>
 #include <Poco/StringTokenizer.h>
 #include <algorithm>
+#include <iterator>
 
 std::string Pothos::System::getRootPath(void)
 {


### PR DESCRIPTION
Example output:

```
ncorgan@edi:~/dev/Pothos/build/PothosCore$ PothosUtil --system-info
Lib Version: 0.7.0-ge9f433b3
API Version: 0.7.0
ABI Version: 0.7
Root Path: /usr/local
Data Path: /usr/local/share/Pothos
User Data: /home/ncorgan/.local/share/Pothos
User Config: /home/ncorgan/.config/Pothos
Runtime Library: /usr/local/lib/libPothos.so.0.7.0
Util Executable: /usr/local/bin/PothosUtil
Dev Include Path: /usr/local/include
Dev Library Path: /usr/local/lib
Module Search Paths:
 * /usr/local/lib/Pothos/modules0.7
```