### PR TITLE
Add Block::prepare()

### DIFF
--- a/include/Pothos/Framework/Block.hpp
+++ b/include/Pothos/Framework/Block.hpp
@@ -50,6 +50,21 @@ public:
     const ThreadPool &getThreadPool(void) const;
 
 protected:
+    /*!
+     * The prepare() method allows the block to say whether it will be able to
+     * do any work, regardless of whether input or output is available. For
+     * example, resources unknown to the framework may be unavailable. This call
+     * happens before the framework determines whether it thinks there is work
+     * for the block.
+     *
+     * The block should not access framework-managed (e.g., ports, messages,
+     * signals/slots) in this call, though it is free to do other things.
+     *
+     * Returns true if the framework should proceed normally and determine
+     * whether work is available, false if the block would be unable to run and
+     * should be passed over.
+     */
+    virtual bool prepare(void);
 
     /*!
      * The work() method, called when resources are available.

--- a/lib/Framework/Block.cpp
+++ b/lib/Framework/Block.cpp
@@ -62,6 +62,11 @@ Pothos::Block::~Block(void)
     this->setThreadPool(ThreadPool());
 }
 
+bool Pothos::Block::prepare(void)
+{
+    return true;
+}
+
 void Pothos::Block::work(void)
 {
     return;

--- a/lib/Framework/WorkerActor.cpp
+++ b/lib/Framework/WorkerActor.cpp
@@ -218,6 +218,7 @@ void Pothos::WorkerActor::setActiveStateOff(void)
 void Pothos::WorkerActor::workTask(void)
 {
     if (not activeState) return;
+    if (not block->prepare()) return;
     this->numTaskCalls++;
     TimeAccumulator taskTime(this->totalTimeTask);
 


### PR DESCRIPTION
This optional hook is called before WorkerActor::preWork(),
determines whether the block is able to perform any work. This hook
allows a block to make an early determination of whether it will be
able to do any work.