### PR TITLE
BufferAccumulator fix for circular buffers.

### DIFF
--- a/include/Pothos/Framework/BufferChunk.hpp
+++ b/include/Pothos/Framework/BufferChunk.hpp
@@ -405,8 +405,8 @@ inline size_t Pothos::BufferChunk::getAlias(void) const
 {
     const auto &buffer = getBuffer();
     if (buffer.getAlias() == 0) return 0;
-    if (address > buffer.getAlias()) return address - buffer.getLength();
-    else return address + buffer.getLength();
+    if (address > buffer.getAlias()) return address - buffer.getAliasOffset();
+    else return address + buffer.getAliasOffset();
 }
 
 inline size_t Pothos::BufferChunk::getEnd(void) const

--- a/include/Pothos/Framework/SharedBuffer.hpp
+++ b/include/Pothos/Framework/SharedBuffer.hpp
@@ -87,6 +87,18 @@ public:
     size_t getAlias(void) const;
 
     /*!
+     * Get the alias offset (non-zero for circular buffers).
+     * Address and alias will point to the same physical memory.
+     */
+    size_t getAliasOffset(void) const;
+
+    /*!
+     * Set the alias address (non-zero for circular buffers).
+     * Address and alias will point to the same physical memory.
+     */
+    void setAlias(const size_t alias);
+
+    /*!
      * Get the end address - front address + length.
      * The end address is non-inclusive.
      * \return the end address
@@ -149,6 +161,16 @@ inline size_t Pothos::SharedBuffer::getLength(void) const
 inline size_t Pothos::SharedBuffer::getAlias(void) const
 {
     return _alias;
+}
+
+inline size_t Pothos::SharedBuffer::getAliasOffset(void) const
+{
+    return _alias ? _alias - _address : 0;
+}
+
+inline void Pothos::SharedBuffer::setAlias(const size_t alias)
+{
+    _alias = alias;
 }
 
 inline size_t Pothos::SharedBuffer::getEnd(void) const

--- a/lib/Framework/BufferAccumulator.cpp
+++ b/lib/Framework/BufferAccumulator.cpp
@@ -181,10 +181,13 @@ void Pothos::BufferAccumulator::require(const size_t numBytes)
     //dont do anything if the buffer is large enough
     if (queue.front().length >= numBytes) return;
 
+    //or if the accumulator is empty
+    if (queue.size() == 1 and _bytesAvailable == 0) return;
+
     //or the accumulator itself doesnt have enough bytes -- but can eventually have enough
     //we deduce this by checking if the requirement is larger than the actual buffer size
     //check the queue size because this optimization requires a single contiguous buffer
-    if (_bytesAvailable < numBytes and queue.size() == 1 and
+    if (_bytesAvailable < numBytes and queue.front().length == _bytesAvailable and
         numBytes <= queue.front().getBuffer().getLength()) return;
 
     //Actually this is ok: assert(not _inPoolBuffer);


### PR DESCRIPTION
Handle chunks from circular buffers without memcpy and with backpressure.
Add functions to allow setting of alias (for circular buffers not
implemented as a part of SharedBuffer) and provide getAliasOffset() to
ensure correct offset.