### PR TITLE
HostInfo: added field to list available SIMD architectures on host device

### DIFF
--- a/include/Pothos/System/HostInfo.hpp
+++ b/include/Pothos/System/HostInfo.hpp
@@ -5,6 +5,7 @@
 ///
 /// \copyright
 /// Copyright (c) 2013-2016 Josh Blum
+///                    2020 Nicholas Corgan
 /// SPDX-License-Identifier: BSL-1.0
 ///
 
@@ -12,6 +13,7 @@
 #include <Pothos/Config.hpp>
 #include <cstddef>
 #include <string>
+#include <vector>
 
 namespace Pothos {
 namespace System {
@@ -43,6 +45,8 @@ public:
 
     //! The process id of the caller
     std::string pid;
+
+    std::vector<std::string> availableSIMDArchitectures;
 };
 
 } //namespace System

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -137,6 +137,8 @@ list(APPEND POTHOS_SOURCES
     System/NumaInfo.cpp
     System/Exception.cpp
 
+    System/Builtin/DetectAvailableSIMDArchitectures.cpp
+
     Object/Object.cpp
     Object/Hash.cpp
     Object/Compare.cpp

--- a/lib/System/Builtin/DetectAvailableSIMDArchitectures.cpp
+++ b/lib/System/Builtin/DetectAvailableSIMDArchitectures.cpp
@@ -1,0 +1,38 @@
+// Copyright (c) 2020 Nicholas Corgan
+// SPDX-License-Identifier: BSL-1.0
+
+#include "simdpp/arch.h"
+#include "simdpp/get_arch_gcc_builtin_cpu_supports.h"
+#include "simdpp/get_arch_linux_cpuinfo.h"
+#include "simdpp/get_arch_raw_cpuid.h"
+#include "simdpp/get_arch_string_list.h"
+
+#include "DetectAvailableSIMDArchitectures.hpp"
+
+//
+// Implementation
+//
+
+#if SIMDPP_HAS_GET_ARCH_RAW_CPUID
+#define SIMDPP_USER_ARCH_INFO simdpp::get_arch_raw_cpuid()
+#elif SIMDPP_HAS_GET_ARCH_GCC_BUILTIN_CPU_SUPPORTS
+#define SIMDPP_USER_ARCH_INFO simdpp::get_arch_gcc_builtin_cpu_supports()
+#elif SIMDPP_HAS_GET_ARCH_LINUX_CPUINFO
+#define SIMDPP_USER_ARCH_INFO simdpp::get_arch_linux_cpuinfo()
+#else
+#error simdpp::Arch::NONE_NULL
+#endif
+
+std::vector<std::string> Pothos::System::detectAvailableSIMDArchitectures()
+{
+    const auto simdppArchInfo = SIMDPP_USER_ARCH_INFO;
+    const auto arches = simdpp::get_architectures();
+
+    std::vector<std::string> simdArchitectures;
+    for(const auto& arch: arches)
+    {
+        if(bool(simdppArchInfo & arch.arch)) simdArchitectures.emplace_back(arch.id);
+    }
+
+    return simdArchitectures;
+}

--- a/lib/System/Builtin/DetectAvailableSIMDArchitectures.hpp
+++ b/lib/System/Builtin/DetectAvailableSIMDArchitectures.hpp
@@ -1,0 +1,13 @@
+// Copyright (c) 2020 Nicholas Corgan
+// SPDX-License-Identifier: BSL-1.0
+
+#include <string>
+#include <vector>
+
+namespace Pothos {
+namespace System {
+
+    std::vector<std::string> detectAvailableSIMDArchitectures();
+
+} // System
+} // Pothos

--- a/lib/System/Builtin/simdpp/arch.h
+++ b/lib/System/Builtin/simdpp/arch.h
@@ -1,0 +1,122 @@
+/*  Copyright (C) 2013-2014  Povilas Kanapickas <povilas@radix.lt>
+
+    Distributed under the Boost Software License, Version 1.0.
+        (See accompanying file LICENSE_1_0.txt or copy at
+            http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef LIBSIMDPP_DISPATCH_ARCH_H
+#define LIBSIMDPP_DISPATCH_ARCH_H
+
+#include <cstdint>
+
+namespace simdpp {
+
+/** Identifies supported instruction set. This type is a bitmask type
+
+    Note: the exact values may change release to release.
+*/
+/*  The values are assigned in such a way that the result of comparison of two
+    ORed flag sets is likely identify which instruction set the binary is more
+    likely to run faster on.
+
+    detail::select_version depends on this.
+*/
+enum class Arch : std::uint32_t {
+    /// Indicates that no SIMD instructions are supported
+    NONE_NULL = 0,
+    /// Indicates x86 SSE2 support
+    X86_SSE2 = 1 << 1,
+    /// Indicates x86 SSE3 support
+    X86_SSE3 = 1 << 2,
+    /// Indicates x86 SSSE3 support
+    X86_SSSE3 = 1 << 3,
+    /// Indicates x86 SSE4.1 support
+    X86_SSE4_1 = 1 << 4,
+    /// Indicates x86 popcnt instruction support (Note: this is not equivalent
+    /// to the ABM CPUID flag, Intel includes the instruction into SSE 4.2)
+    X86_POPCNT_INSN = 1 << 5,
+    /// Indicates x86 AVX support
+    X86_AVX = 1 << 6,
+    /// Indicates x86 AVX2 support
+    X86_AVX2 = 1 << 7,
+    /// Indicates x86 FMA3 (Intel) support
+    X86_FMA3 = 1 << 8,
+    /// Indicates x86 FMA4 (AMD) support
+    X86_FMA4 = 1 << 9,
+    /// Indicates x86 XOP (AMD) support
+    X86_XOP = 1 << 10,
+    /// Indicates x86 AVX-512F suppotr
+    X86_AVX512F = 1 << 11,
+    /// Indicates x86 AVX-512BW suppotr
+    X86_AVX512BW = 1 << 12,
+    /// Indicates x86 AVX-512DQ suppotr
+    X86_AVX512DQ = 1 << 13,
+    /// Indicates x86 AVX-512VL suppotr
+    X86_AVX512VL = 1 << 14,
+
+    /// Indicates ARM NEON support (SP and DP floating-point math is executed
+    /// on VFP)
+    ARM_NEON = 1 << 0,
+    /// Indicates ARM NEON support (SP floating-point math is executed on NEON,
+    /// DP floating-point math is executed on VFP)
+    ARM_NEON_FLT_SP = 1 << 1,
+
+    /// Indicates POWER ALTIVEC support.
+    POWER_ALTIVEC = 1 << 0,
+
+    /// Indicates POWER VSX support available since Power ISA 2.06
+    POWER_VSX_206 = 1 << 1,
+
+    /// Indicates POWER VSX support available since Power ISA 2.07
+    POWER_VSX_207 = 1 << 2,
+
+    /// Indicates MIPS MSA support
+    MIPS_MSA = 1 << 0
+};
+
+/// Bitwise operators for @c Arch
+inline Arch& operator|=(Arch& x, const Arch& y)
+{
+    using T = std::uint32_t;
+    x = static_cast<Arch>(static_cast<T>(x) | static_cast<T>(y));
+    return x;
+}
+
+inline Arch& operator&=(Arch& x, const Arch& y)
+{
+    using T = std::uint32_t;
+    x = static_cast<Arch>(static_cast<T>(x) & static_cast<T>(y));
+    return x;
+}
+
+inline Arch operator|(const Arch& x, const Arch& y)
+{
+    using T = std::uint32_t;
+    return static_cast<Arch>(static_cast<T>(x) | static_cast<T>(y));
+}
+
+inline Arch operator&(const Arch& x, const Arch& y)
+{
+    using T = std::uint32_t;
+    return static_cast<Arch>(static_cast<T>(x) & static_cast<T>(y));
+}
+
+inline Arch operator~(const Arch& x)
+{
+    using T = std::uint32_t;
+    return static_cast<Arch>(~static_cast<T>(x));
+}
+
+/// Checks if the bits set in @a required is a subset of bits set in @a current.
+inline bool test_arch_subset(Arch current, Arch required)
+{
+    if ((~current & required) == Arch::NONE_NULL) {
+        return true;
+    }
+    return false;
+}
+
+} // namespace simdpp
+
+#endif

--- a/lib/System/Builtin/simdpp/get_arch_gcc_builtin_cpu_supports.h
+++ b/lib/System/Builtin/simdpp/get_arch_gcc_builtin_cpu_supports.h
@@ -1,0 +1,72 @@
+/*  Copyright (C) 2013  Povilas Kanapickas <povilas@radix.lt>
+
+    Distributed under the Boost Software License, Version 1.0.
+        (See accompanying file LICENSE_1_0.txt or copy at
+            http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef LIBSIMDPP_DISPATCH_GET_ARCH_GCC_BUILTIN_CPU_SUPPORTS_H
+#define LIBSIMDPP_DISPATCH_GET_ARCH_GCC_BUILTIN_CPU_SUPPORTS_H
+
+#if ((__GNUC__ >= 4) && (__GNUC_MINOR__ >= 8)) && (__i386__ || __amd64__)
+#define SIMDPP_HAS_GET_ARCH_GCC_BUILTIN_CPU_SUPPORTS 1
+
+#include "arch.h"
+
+namespace simdpp {
+
+/** Retrieves supported architecture using GCC __builtin_cpu_supports function.
+    Works only on x86.
+*/
+inline Arch get_arch_gcc_builtin_cpu_supports()
+{
+    Arch arch_info;
+#if (__GNUC__ > 4)
+    if (__builtin_cpu_supports("avx512f")) { // since 5.0
+        arch_info |= Arch::X86_SSE2;
+        arch_info |= Arch::X86_SSE3;
+        arch_info |= Arch::X86_SSSE3;
+        arch_info |= Arch::X86_SSE4_1;
+        arch_info |= Arch::X86_AVX;
+        arch_info |= Arch::X86_AVX2;
+        arch_info |= Arch::X86_FMA3;
+        arch_info |= Arch::X86_AVX512F;
+    } else
+#endif
+    if (__builtin_cpu_supports("avx2")) {
+        arch_info |= Arch::X86_SSE2;
+        arch_info |= Arch::X86_SSE3;
+        arch_info |= Arch::X86_SSSE3;
+        arch_info |= Arch::X86_SSE4_1;
+        arch_info |= Arch::X86_AVX;
+        arch_info |= Arch::X86_AVX2;
+    } else if (__builtin_cpu_supports("avx")) {
+        arch_info |= Arch::X86_SSE2;
+        arch_info |= Arch::X86_SSE3;
+        arch_info |= Arch::X86_SSSE3;
+        arch_info |= Arch::X86_SSE4_1;
+        arch_info |= Arch::X86_AVX;
+    } else if (__builtin_cpu_supports("sse4.1")) {
+        arch_info |= Arch::X86_SSE2;
+        arch_info |= Arch::X86_SSE3;
+        arch_info |= Arch::X86_SSSE3;
+        arch_info |= Arch::X86_SSE4_1;
+    } else if (__builtin_cpu_supports("ssse3")) {
+        arch_info |= Arch::X86_SSE2;
+        arch_info |= Arch::X86_SSE3;
+        arch_info |= Arch::X86_SSSE3;
+    } else if (__builtin_cpu_supports("sse3")) {
+        arch_info |= Arch::X86_SSE3;
+        arch_info |= Arch::X86_SSE2;
+    } else if (__builtin_cpu_supports("sse2")) {
+        arch_info |= Arch::X86_SSE2;
+    }
+    if (__builtin_cpu_supports("popcnt"))
+        arch_info |= Arch::X86_POPCNT_INSN;
+
+    return arch_info;
+}
+} // namespace simdpp
+
+#endif
+#endif

--- a/lib/System/Builtin/simdpp/get_arch_linux_cpuinfo.h
+++ b/lib/System/Builtin/simdpp/get_arch_linux_cpuinfo.h
@@ -1,0 +1,121 @@
+/*  Copyright (C) 2013-2017  Povilas Kanapickas <povilas@radix.lt>
+
+    Distributed under the Boost Software License, Version 1.0.
+        (See accompanying file LICENSE_1_0.txt or copy at
+            http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef LIBSIMDPP_DISPATCH_GET_ARCH_LINUX_CPUINFO_H
+#define LIBSIMDPP_DISPATCH_GET_ARCH_LINUX_CPUINFO_H
+
+#if __linux__ && (__arm__ || __aarch64__ || __i386__ || __amd64__)
+#define SIMDPP_HAS_GET_ARCH_LINUX_CPUINFO 1
+
+#include <algorithm>
+#include <iostream>
+#include <sstream>
+#include <fstream>
+#include <iterator>
+#include <map>
+#include <vector>
+
+#include "arch.h"
+
+namespace simdpp {
+
+/** Retrieves supported architecture from Linux /proc/cpuinfo file.
+
+    Works on X86 and ARM.
+*/
+inline Arch get_arch_linux_cpuinfo()
+{
+    Arch res = Arch::NONE_NULL;
+
+    std::map<std::string, Arch> features;
+    std::string ident;
+
+#if __arm__
+    ident = "Features\t";
+    features["neon"] = Arch::ARM_NEON | Arch::ARM_NEON_FLT_SP;
+
+#elif __aarch64__
+    ident = "Features\t";
+    features["asimd"] = Arch::ARM_NEON | Arch::ARM_NEON_FLT_SP;
+
+#elif __i386__ || __amd64__
+    Arch a_sse2 = Arch::X86_SSE2;
+    Arch a_sse3 = a_sse2 | Arch::X86_SSE3;
+    Arch a_ssse3 = a_sse3 | Arch::X86_SSSE3;
+    Arch a_sse4_1 = a_ssse3 | Arch::X86_SSE4_1;
+    Arch a_popcnt = Arch::X86_POPCNT_INSN;
+    Arch a_avx = a_sse4_1 | Arch::X86_AVX;
+    Arch a_avx2 = a_avx | Arch::X86_AVX2;
+    Arch a_fma3 = a_sse3 | Arch::X86_FMA3;
+    Arch a_fma4 = a_sse3 | Arch::X86_FMA4;
+    Arch a_xop = a_sse3 | Arch::X86_XOP;
+    Arch a_avx512f = a_avx2 | Arch::X86_AVX512F;
+    Arch a_avx512bw = a_avx512f | Arch::X86_AVX512BW;
+    Arch a_avx512dq = a_avx512f | Arch::X86_AVX512DQ;
+    Arch a_avx512vl = a_avx512f | Arch::X86_AVX512VL;
+
+    ident = "flags\t";
+    features["sse2"] = a_sse2;
+    features["pni"] = a_sse3;
+    features["ssse3"] = a_ssse3;
+    features["sse4_1"] = a_sse4_1;
+    features["avx"] = a_avx;
+    features["avx2"] = a_avx2;
+    features["popcnt"] = a_popcnt;
+    features["fma"] = a_fma3;
+    features["fma4"] = a_fma4;
+    features["xop"] = a_xop;
+    features["avx512f"] = a_avx512f;
+    features["avx512bw"] = a_avx512bw;
+    features["avx512dq"] = a_avx512dq;
+    features["avx512vl"] = a_avx512vl;
+#else
+    return res;
+#endif
+
+    std::ifstream in("/proc/cpuinfo");
+
+    if (!in) {
+        return res;
+    }
+
+    std::string line;
+    while (std::getline(in, line)) {
+        // Check whether identification string matches
+        if (line.length() < ident.length()) {
+            continue;
+        }
+        auto r = std::mismatch(ident.begin(), ident.end(), line.begin());
+        if (r.first != ident.end()) {
+            continue;
+        }
+
+        // Get the items
+        std::istringstream sin(std::string(r.second, line.end()));
+        std::vector<std::string> items;
+
+        std::copy(std::istream_iterator<std::string>(sin),
+                  std::istream_iterator<std::string>(),
+                  std::back_inserter(items));
+
+        // Match items to known features
+        for (auto& item : items) {
+            auto it = features.find(item);
+            if (it == features.end()) {
+                continue;
+            }
+            res |= it->second;
+        }
+    }
+
+    return res;
+}
+
+} // namespace simdpp
+
+#endif
+#endif

--- a/lib/System/Builtin/simdpp/get_arch_raw_cpuid.h
+++ b/lib/System/Builtin/simdpp/get_arch_raw_cpuid.h
@@ -1,0 +1,178 @@
+/*  Copyright (C) 2014  Povilas Kanapickas <povilas@radix.lt>
+
+    Distributed under the Boost Software License, Version 1.0.
+        (See accompanying file LICENSE_1_0.txt or copy at
+            http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef LIBSIMDPP_DISPATCH_GET_ARCH_RAW_CPUID_H
+#define LIBSIMDPP_DISPATCH_GET_ARCH_RAW_CPUID_H
+
+// Copied from simdpp/setup_arch.h
+#if !defined(SIMDPP_X86) && __i386__ || __i386 || _M_IX86 || __amd64__ || __x64_64__ || _M_AMD64 || _M_X64
+#define SIMDPP_X86 1
+#elif _M_ARM || __arm__ || __aarch64__
+#define SIMDPP_ARM 1
+#elif __powerpc__ || __powerpc64__
+#define SIMDPP_PPC 1
+#elif __mips__
+#define SIMDPP_MIPS 1
+#endif
+
+#if SIMDPP_X86 && (__clang__ || __GNUC__ || __INTEL_COMPILER || _MSC_VER)
+#define SIMDPP_HAS_GET_ARCH_RAW_CPUID 1
+
+#include "arch.h"
+
+#include <cstdint>
+
+#if __GNUC__
+#include <cpuid.h>
+#endif
+
+#if _MSC_VER
+#include <intrin.h>     // __cpuidex on MSVC 2017
+#include <immintrin.h>
+#endif
+
+namespace simdpp {
+namespace detail {
+
+inline void get_cpuid(unsigned level, unsigned subleaf, unsigned* eax, unsigned* ebx,
+                      unsigned* ecx, unsigned* edx)
+{
+#if __clang__ || (__INTEL_COMPILER && !_MSC_VER)
+    // Older versions of clang don't support subleafs, which leads to inability
+    // to detect AVX2 for example. On ICC there's no proper cpuid intrinsic.
+#if SIMDPP_32_BITS
+    __asm("cpuid" : "=a"(*eax), "=b" (*ebx), "=c"(*ecx), "=d"(*edx) \
+                  : "0"(level), "2"(subleaf));
+#else
+    // x86-64 uses %rbx as the base register, so preserve it.
+    __asm("xchgq  %%rbx,%q1\n" \
+          "cpuid\n" \
+          "xchgq  %%rbx,%q1" \
+            : "=a"(*eax), "=b" (*ebx), "=c"(*ecx), "=d"(*edx) \
+            : "0"(level), "2"(subleaf));
+#endif
+#elif __GNUC__
+    __cpuid_count(level, subleaf, *eax, *ebx, *ecx, *edx);
+#elif _MSC_VER
+    uint32_t regs[4];
+    __cpuidex((int*) regs, level, subleaf);
+    *eax = regs[0];
+    *ebx = regs[1];
+    *ecx = regs[2];
+    *edx = regs[3];
+#else
+    #error "unsupported compiler"
+#endif
+}
+
+inline uint64_t get_xcr(unsigned level)
+{
+#if (defined (_MSC_FULL_VER) && _MSC_FULL_VER >= 160040000) ||                  \
+    (defined (__INTEL_COMPILER) && __INTEL_COMPILER >= 1200)
+    return _xgetbv(level);
+#elif defined(__GNUC__) || defined(__clang__)
+    uint32_t eax, edx;
+    __asm("xgetbv" : "=a"(eax),"=d"(edx) : "c"(level) : );
+    return eax | (uint64_t(edx) << 32);
+#else
+    return 0;
+#endif
+}
+
+enum cpu_manufacturer {
+    CPU_INTEL,
+    CPU_AMD,
+    CPU_UNKNOWN
+};
+
+static inline cpu_manufacturer
+    get_cpu_manufacturer(uint32_t ebx, uint32_t ecx, uint32_t edx)
+{
+    if (ebx == 0x756E6547 && ecx == 0x6C65746E && edx == 0x49656E69)
+        return CPU_INTEL; // "GenuineIntel"
+    if (ebx == 0x68747541 && ecx == 0x444D4163 && edx == 0x69746E65)
+        return CPU_AMD; // "AuthenticAMD"
+    return CPU_UNKNOWN;
+}
+
+} // namespace detail
+
+/** Retrieves supported architecture using the CPUID instruction. Works only on
+    x86.
+*/
+inline Arch get_arch_raw_cpuid()
+{
+    Arch arch_info = Arch::NONE_NULL;
+
+    uint32_t eax, ebx, ecx, edx;
+    bool xsave_xrstore_avail = false;
+
+    simdpp::detail::get_cpuid(0, 0, &eax, &ebx, &ecx, &edx);
+    unsigned max_cpuid_level = eax;
+    simdpp::detail::cpu_manufacturer mfg =
+            simdpp::detail::get_cpu_manufacturer(ebx, ecx, edx);
+
+    simdpp::detail::get_cpuid(0x80000000, 0, &eax, &ebx, &ecx, &edx);
+    unsigned max_ex_cpuid_level = eax;
+
+    if (max_cpuid_level >= 0x00000001) {
+        simdpp::detail::get_cpuid(0x00000001, 0, &eax, &ebx, &ecx, &edx);
+
+        if (edx & (1u << 26))
+            arch_info |= Arch::X86_SSE2;
+        if (ecx & (1u << 0))
+            arch_info |= Arch::X86_SSE3;
+        if (ecx & (1u << 9))
+            arch_info |= Arch::X86_SSSE3;
+        if (ecx & (1u << 19))
+            arch_info |= Arch::X86_SSE4_1;
+        if (ecx & (1u << 20) && mfg == simdpp::detail::CPU_INTEL)
+            arch_info |= Arch::X86_POPCNT_INSN; // popcnt is included in SSE4.2 on Intel
+        if (ecx & (1u << 23))
+            arch_info |= Arch::X86_POPCNT_INSN;
+        if (ecx & (1u << 12))
+            arch_info |= Arch::X86_FMA3;
+        if (ecx & (1u << 26)) {
+            // XSAVE/XRSTORE available on hardware, now check OS support
+            uint64_t xcr = simdpp::detail::get_xcr(0);
+            if ((xcr & 6) == 6)
+                xsave_xrstore_avail = true;
+        }
+
+        if (ecx & (1u << 28) && xsave_xrstore_avail)
+            arch_info |= Arch::X86_AVX;
+    }
+    if (max_ex_cpuid_level >= 0x80000001) {
+        simdpp::detail::get_cpuid(0x80000001, 0, &eax, &ebx, &ecx, &edx);
+        if (ecx & (1u << 16))
+            arch_info |= Arch::X86_FMA4;
+        if (ecx & (1u << 11))
+            arch_info |= Arch::X86_XOP;
+    }
+
+    if (max_cpuid_level >= 0x00000007) {
+        simdpp::detail::get_cpuid(0x00000007, 0, &eax, &ebx, &ecx, &edx);
+        if (ebx & (1u << 5) && xsave_xrstore_avail)
+            arch_info |= Arch::X86_AVX2;
+        if (ebx & (1u << 16) && xsave_xrstore_avail)
+            arch_info |= Arch::X86_AVX512F;
+        if (ebx & (1u << 30) && xsave_xrstore_avail)
+            arch_info |= Arch::X86_AVX512BW;
+        if (ebx & (1u << 17) && xsave_xrstore_avail)
+            arch_info |= Arch::X86_AVX512DQ;
+        if (ebx & (1u << 31) && xsave_xrstore_avail)
+            arch_info |= Arch::X86_AVX512VL;
+    }
+
+    return arch_info;
+}
+
+} // namespace simdpp
+
+#endif // #if SIMDPP_X86 && ...
+
+#endif

--- a/lib/System/Builtin/simdpp/get_arch_string_list.h
+++ b/lib/System/Builtin/simdpp/get_arch_string_list.h
@@ -1,0 +1,110 @@
+/*  Copyright (C) 2015  Povilas Kanapickas <povilas@radix.lt>
+
+    Distributed under the Boost Software License, Version 1.0.
+        (See accompanying file LICENSE_1_0.txt or copy at
+            http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef LIBSIMDPP_DISPATCH_GET_ARCH_STRING_LIST_H
+#define LIBSIMDPP_DISPATCH_GET_ARCH_STRING_LIST_H
+
+#include <vector>
+#include <cstring>
+#include <string>
+
+//
+// #defines copied from simdpp/setup_arch.h
+//
+
+#if !defined(SIMDPP_X86) && (__i386__ || __i386 || _M_IX86 || __amd64__ || __x64_64__ || _M_AMD64 || _M_X64)
+#define SIMDPP_X86 1
+#elif !defined(SIMDPP_ARM) && (_M_ARM || __arm__ || __aarch64__)
+#define SIMDPP_ARM 1
+#elif !defined(SIMDPP_PPC) && (__powerpc__ || __powerpc64__)
+#define SIMDPP_PPC 1
+#elif !defined(SIMDPP_MIPS) && __mips__
+#define SIMDPP_MIPS 1
+#endif
+
+#ifndef SIMDPP_64_BITS
+#if __amd64__ || __x86_64__ || _M_AMD64 || __aarch64__ || __powerpc64__
+#define SIMDPP_64_BITS 1
+#define SIMDPP_32_BITS 0
+#else
+#define SIMDPP_32_BITS 1
+#define SIMDPP_64_BITS 0
+#endif
+#endif
+
+#include "arch.h"
+
+namespace simdpp {
+
+struct ArchDesc {
+    std::string id;
+    Arch arch;
+
+    ArchDesc(const std::string& i, Arch a) : id(i), arch(a) {}
+};
+
+/** Retrieves supported architecture from given string list. The architecture
+    names are the same as ids specified in simdpp/detail/insn_id.h
+*/
+inline std::vector<ArchDesc> get_architectures()
+{
+    std::vector<ArchDesc> features;
+
+#if SIMDPP_ARM && SIMDPP_32_BITS
+    features.emplace_back("neon", Arch::ARM_NEON);
+    features.emplace_back("neonfltsp", Arch::ARM_NEON | Arch::ARM_NEON_FLT_SP);
+#elif SIMDPP_ARM && SIMDPP_64_BITS
+    features.emplace_back("neon", Arch::ARM_NEON | Arch::ARM_NEON_FLT_SP);
+    features.emplace_back("neonfltsp", Arch::ARM_NEON | Arch::ARM_NEON_FLT_SP);
+#elif SIMDPP_X86
+    Arch a_sse2 = Arch::X86_SSE2;
+    Arch a_sse3 = a_sse2 | Arch::X86_SSE3;
+    Arch a_ssse3 = a_sse3 | Arch::X86_SSSE3;
+    Arch a_sse4_1 = a_ssse3 | Arch::X86_SSE4_1;
+    Arch a_popcnt = Arch::X86_POPCNT_INSN;
+    Arch a_avx = a_sse4_1 | Arch::X86_AVX;
+    Arch a_avx2 = a_avx | Arch::X86_AVX2;
+    Arch a_fma3 = a_sse3 | Arch::X86_FMA3;
+    Arch a_fma4 = a_sse3 | Arch::X86_FMA4;
+    Arch a_xop = a_sse3 | Arch::X86_XOP;
+    Arch a_avx512f = a_avx2 | Arch::X86_AVX512F;
+    Arch a_avx512bw = a_avx512f | Arch::X86_AVX512BW;
+    Arch a_avx512dq = a_avx512f | Arch::X86_AVX512DQ;
+    Arch a_avx512vl = a_avx512f | Arch::X86_AVX512VL;
+
+    features.emplace_back("sse2", a_sse2);
+    features.emplace_back("sse3", a_sse3);
+    features.emplace_back("ssse3", a_ssse3);
+    features.emplace_back("sse4p1", a_sse4_1);
+    features.emplace_back("popcnt", a_popcnt);
+    features.emplace_back("avx", a_avx);
+    features.emplace_back("avx2", a_avx2);
+    features.emplace_back("fma3", a_fma3);
+    features.emplace_back("fma4", a_fma4);
+    features.emplace_back("xop", a_xop);
+    features.emplace_back("avx512f", a_avx512f);
+    features.emplace_back("avx512bw", a_avx512bw);
+    features.emplace_back("avx512dq", a_avx512dq);
+    features.emplace_back("avx512vl", a_avx512vl);
+#elif SIMDPP_PPC
+    Arch a_altivec = Arch::POWER_ALTIVEC;
+    Arch a_vsx_206 = a_altivec | Arch::POWER_VSX_206;
+    Arch a_vsx_207 = a_vsx_206 | Arch::POWER_VSX_207;
+
+    features.emplace_back("altivec", a_altivec);
+    features.emplace_back("vsx_206", a_vsx_206);
+    features.emplace_back("vsx_207", a_vsx_207);
+#elif SIMDPP_MIPS
+    features.emplace_back("msa", Arch::MIPS_MSA);
+#endif
+
+    return features;
+}
+
+} // namespace simdpp
+
+#endif

--- a/lib/System/HostInfo.cpp
+++ b/lib/System/HostInfo.cpp
@@ -1,5 +1,8 @@
 // Copyright (c) 2013-2014 Josh Blum
+//                    2020 Nicholas Corgan
 // SPDX-License-Identifier: BSL-1.0
+
+#include "Builtin/DetectAvailableSIMDArchitectures.hpp"
 
 #include <Poco/Process.h>
 #include <Pothos/System/HostInfo.hpp>
@@ -22,6 +25,7 @@ Pothos::System::HostInfo Pothos::System::HostInfo::get(void)
     info.nodeId = Poco::Environment::nodeId();
     info.processorCount = Poco::Environment::processorCount();
     info.pid = std::to_string(Poco::Process::id());
+    info.availableSIMDArchitectures = Pothos::System::detectAvailableSIMDArchitectures();
     return info;
 }
 
@@ -44,6 +48,7 @@ void serialize(Archive &ar, Pothos::System::HostInfo &t, const unsigned int)
     ar & t.nodeId;
     ar & t.processorCount;
     ar & t.pid;
+    ar & t.availableSIMDArchitectures;
 }
 }}
 


### PR DESCRIPTION
* Internally uses libsimdpp detection code (BSL), converts to string vector