### PR TITLE
lib: revert change to BufferAccumulator.cpp from PR #205

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -4,6 +4,7 @@ Release 0.7.1 (pending)
 ==========================
 
 - Fix std::vector<bool> emplace_back missing
+- Revert BufferAccumulator.cpp from #205
 
 Release 0.7.0 (2020-07-19)
 ==========================

--- a/lib/Framework/BufferAccumulator.cpp
+++ b/lib/Framework/BufferAccumulator.cpp
@@ -181,13 +181,10 @@ void Pothos::BufferAccumulator::require(const size_t numBytes)
     //dont do anything if the buffer is large enough
     if (queue.front().length >= numBytes) return;
 
-    //or if the accumulator is empty
-    if (queue.size() == 1 and _bytesAvailable == 0) return;
-
     //or the accumulator itself doesnt have enough bytes -- but can eventually have enough
     //we deduce this by checking if the requirement is larger than the actual buffer size
     //check the queue size because this optimization requires a single contiguous buffer
-    if (_bytesAvailable < numBytes and queue.front().length == _bytesAvailable and
+    if (_bytesAvailable < numBytes and queue.size() == 1 and
         numBytes <= queue.front().getBuffer().getLength()) return;
 
     //Actually this is ok: assert(not _inPoolBuffer);


### PR DESCRIPTION
The change caused the accumulation logic to skip when multiple buffers
should have been accumulated into one. This means hanging onto buffers
and stalling. See PR #205

* closes https://github.com/pothosware/PothosFlow/issues/197