### PR TITLE
PothosUtil: added option to print type conversions for a given type

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -32,6 +32,7 @@ list(APPEND SOURCES
     PothosUtilProxyEnvironmentInfo.cpp
     PothosUtilSIMDFeatures.cpp
     PothosUtilGenerateSIMDDispatchers.cpp
+    PothosUtilListTypeConversions.cpp
 )
 add_executable(PothosUtil ${SOURCES})
 target_link_libraries(PothosUtil Pothos ${Pothos_LIBRARIES})

--- a/apps/PothosUtil.cpp
+++ b/apps/PothosUtil.cpp
@@ -186,6 +186,13 @@ protected:
             .repeatable(false)
             .argument("simdArches")
             .binding("simdArches"));
+
+        options.addOption(Poco::Util::Option("type-conversions", "", "Print types convertible to and from a given type")
+            .required(false)
+            .repeatable(false)
+            .argument("type", false /*optional*/)
+            .binding("type")
+            .callback(Poco::Util::OptionCallback<PothosUtil>(this, &PothosUtil::printTypeConversions)));
     }
 
     void handleOption(const std::string &name, const std::string &value)

--- a/apps/PothosUtil.hpp
+++ b/apps/PothosUtil.hpp
@@ -27,6 +27,7 @@ public:
     void printProxyEnvironmentInfo(const std::string &, const std::string &);
     void printSIMDFeatures(void);
     void generateSIMDDispatchers(const std::string &, const std::string &);
+    void printTypeConversions(const std::string &, const std::string &);
 
     //! Variables passed in via the --vars option
     std::vector<std::pair<std::string, std::string>> _vars;

--- a/apps/PothosUtilListTypeConversions.cpp
+++ b/apps/PothosUtilListTypeConversions.cpp
@@ -1,0 +1,105 @@
+// Copyright (c) 2021 Nicholas Corgan
+// SPDX-License-Identifier: BSL-1.0
+
+#include "PothosUtil.hpp"
+
+#include <Pothos/Callable.hpp>
+#include <Pothos/Plugin.hpp>
+#include <Pothos/Proxy.hpp>
+#include <Pothos/System/Paths.hpp>
+#include <Pothos/Util/TypeInfo.hpp>
+
+#include <Poco/Format.h>
+#include <Poco/Path.h>
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+static bool isConvertCallable(const Pothos::Callable& callable)
+{
+    if(callable.getNumArgs() != 1) return false;
+    if(callable.type(-1) == typeid(void)) return false;
+
+    return true;
+}
+
+// Assumption: callable type validated
+static void getConvertTypeNames(
+    const Pothos::Callable& callable,
+    std::string* srcTypeOut,
+    std::string* dstTypeOut)
+{
+    *srcTypeOut = Pothos::Util::typeInfoToString(callable.type(0));
+    *dstTypeOut = Pothos::Util::typeInfoToString(callable.type(-1));
+}
+
+static void getTypeConversions(
+    const Pothos::PluginPath& pluginPath,
+    const std::string& typeName,
+    std::vector<std::string>* convertibleFromOut,
+    std::vector<std::string>* convertibleToOut)
+{
+    Pothos::Plugin plugin(pluginPath);
+    if(!Pothos::PluginRegistry::empty(pluginPath))
+    {
+        plugin = Pothos::PluginRegistry::get(pluginPath);
+    }
+    const auto& pluginObj = plugin.getObject();
+
+    if(pluginObj.type() == typeid(Pothos::Callable))
+    {
+        const auto& callable = pluginObj.extract<Pothos::Callable>();
+        if(isConvertCallable(callable))
+        {
+            std::string srcType;
+            std::string dstType;
+            getConvertTypeNames(callable, &srcType, &dstType);
+
+            if(srcType == typeName)      convertibleFromOut->emplace_back(std::move(dstType));
+            else if(dstType == typeName) convertibleToOut->emplace_back(std::move(srcType));
+        }
+    }
+
+    for(const auto& subpath: Pothos::PluginRegistry::list(pluginPath))
+    {
+        getTypeConversions(
+            pluginPath.join(subpath),
+            typeName,
+            convertibleFromOut,
+            convertibleToOut);
+    }
+}
+
+void PothosUtilBase::printTypeConversions(const std::string&, const std::string&)
+{
+    Pothos::ScopedInit init;
+
+    const auto typeName = this->config().getString("type");
+    if (typeName.empty())
+    {
+        std::cout << ">>> Specify --type=typeName to list conversions..." << std::endl;
+        return;
+    }
+
+    std::vector<std::string> convertibleFrom;
+    std::vector<std::string> convertibleTo;
+    getTypeConversions(
+        Pothos::PluginPath("/object/convert"),
+        typeName,
+        &convertibleFrom,
+        &convertibleTo);
+
+    std::cout << "Convertible from " << typeName << ":" << std::endl;
+    for(const auto& type: convertibleFrom)
+    {
+        std::cout << " * " << type << std::endl;
+    }
+    std::cout << std::endl;
+
+    std::cout << "Convertible to " << typeName << ":" << std::endl;
+    for(const auto& type: convertibleTo)
+    {
+        std::cout << " * " << type << std::endl;
+    }
+}

--- a/lib/Util/TypeInfo.cpp
+++ b/lib/Util/TypeInfo.cpp
@@ -1,7 +1,19 @@
 // Copyright (c) 2013-2016 Josh Blum
+//                    2021 Nicholas Corgan
 // SPDX-License-Identifier: BSL-1.0
 
+#include <Pothos/Object.hpp>
+#include <Pothos/Object/Containers.hpp>
+#include <Pothos/Proxy.hpp>
 #include <Pothos/Util/TypeInfo.hpp>
+
+#include <complex>
+#include <cstdint>
+#include <map>
+#include <set>
+#include <typeinfo>
+#include <unordered_map>
+#include <vector>
 
 //demangle support for pretty strings
 #ifdef __GNUG__
@@ -11,9 +23,50 @@
 
 std::string Pothos::Util::typeInfoToString(const std::type_info &type)
 {
-    //Since std::string is used a lot and often has a complicated template name,
-    //we just enforce returning a simple display name for the std::string type.
-    if (type == typeid(std::string)) return "std::string";
+    #define TypeNameEntry(T) \
+        {typeid(T).hash_code(), #T}
+
+    #define ContainerTypeNameEntries(T) \
+        TypeNameEntry(std::set<T>), \
+        TypeNameEntry(std::vector<T>), \
+        TypeNameEntry(std::vector<std::vector<T>>)
+
+    #define NumericTypeNameEntries(T) \
+        TypeNameEntry(T), \
+        ContainerTypeNameEntries(T), \
+        ContainerTypeNameEntries(std::complex<T>)
+
+    static const std::unordered_map<size_t, std::string> CustomTypeNames =
+    {
+        TypeNameEntry(std::string),
+        TypeNameEntry(Pothos::ObjectKwargs),
+        TypeNameEntry(Pothos::ObjectMap),
+        TypeNameEntry(Pothos::ObjectSet),
+        TypeNameEntry(Pothos::ObjectVector),
+        TypeNameEntry(Pothos::ProxyMap),
+        TypeNameEntry(Pothos::ProxySet),
+        TypeNameEntry(Pothos::ProxyVector),
+        TypeNameEntry(Pothos::ProxyEnvironment::Sptr),
+        TypeNameEntry(Pothos::ProxyEnvironmentArgs),
+        TypeNameEntry(Pothos::ProxyConvertPair),
+        NumericTypeNameEntries(bool),
+        NumericTypeNameEntries(char),
+        NumericTypeNameEntries(signed char),
+        NumericTypeNameEntries(short),
+        NumericTypeNameEntries(int),
+        NumericTypeNameEntries(long),
+        NumericTypeNameEntries(long long),
+        NumericTypeNameEntries(unsigned char),
+        NumericTypeNameEntries(unsigned short),
+        NumericTypeNameEntries(unsigned int),
+        NumericTypeNameEntries(unsigned long),
+        NumericTypeNameEntries(unsigned long long),
+        NumericTypeNameEntries(float),
+        NumericTypeNameEntries(double),
+    };
+
+    auto typeNameIter = CustomTypeNames.find(type.hash_code());
+    if(typeNameIter != CustomTypeNames.end()) return typeNameIter->second;
 
     const char *name = type.name();
     #ifdef HAVE_CXA_DEMANGLE


### PR DESCRIPTION
* typeInfoToString: more types output nicer type names

**Example output:**

```
PothosUtil --type-conversions="std::vector<int>"
Convertible from std::vector<int>:
 * std::vector<long long>
 * Pothos::ProxyVector

Convertible to std::vector<int>:
 * std::vector<long long>
 * std::vector<unsigned long long>
 * std::vector<double>
 * std::vector<std::complex<double>>
 * Pothos::ProxyVector
```