### PR TITLE
Compiler support read pipe fix

### DIFF
--- a/lib/Util/Builtin/ClangCompilerSupport.cpp
+++ b/lib/Util/Builtin/ClangCompilerSupport.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016 Josh Blum
+// Copyright (c) 2014-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Util/Compiler.hpp>
@@ -84,14 +84,15 @@ std::string ClangCompilerSupport::compileCppModule(const Pothos::Util::CompilerA
     Poco::ProcessHandle ph(Poco::Process::launch(
         "clang++", args, &inPipe, &outPipe, &outPipe, env));
 
+    //read into output buffer until pipe is closed
+    Poco::PipeInputStream is(outPipe);
+    std::string outBuff;
+    for (std::string line; std::getline(is, line);) outBuff += line;
+
     //handle error case
-    if (ph.wait() != 0)
+    if (ph.wait() != 0 or not Poco::File(outPath.c_str()).exists())
     {
-        Poco::PipeInputStream errStream(outPipe);
-        const std::string errMsgBuff = std::string(
-            std::istreambuf_iterator<char>(errStream),
-            std::istreambuf_iterator<char>());
-        throw Pothos::Exception("ClangCompilerSupport::compileCppModule", errMsgBuff);
+        throw Pothos::Exception("ClangCompilerSupport::compileCppModule", outBuff);
     }
 
     //return output file path

--- a/lib/Util/Builtin/ClangCompilerSupport.cpp
+++ b/lib/Util/Builtin/ClangCompilerSupport.cpp
@@ -87,7 +87,7 @@ std::string ClangCompilerSupport::compileCppModule(const Pothos::Util::CompilerA
     //read into output buffer until pipe is closed
     Poco::PipeInputStream is(outPipe);
     std::string outBuff;
-    for (std::string line; std::getline(is, line);) outBuff += line;
+    for (std::string line; std::getline(is, line);) outBuff += line+'\n';
 
     //handle error case
     if (ph.wait() != 0 or not Poco::File(outPath.c_str()).exists())

--- a/lib/Util/Builtin/GccCompilerSupport.cpp
+++ b/lib/Util/Builtin/GccCompilerSupport.cpp
@@ -86,7 +86,7 @@ std::string GccCompilerSupport::compileCppModule(const Pothos::Util::CompilerArg
     //read into output buffer until pipe is closed
     Poco::PipeInputStream is(outPipe);
     std::string outBuff;
-    for (std::string line; std::getline(is, line);) outBuff += line;
+    for (std::string line; std::getline(is, line);) outBuff += line+'\n';
 
     //handle error case
     if (ph.wait() != 0 or not Poco::File(outPath.c_str()).exists())

--- a/lib/Util/Builtin/GccCompilerSupport.cpp
+++ b/lib/Util/Builtin/GccCompilerSupport.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016 Josh Blum
+// Copyright (c) 2014-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Util/Compiler.hpp>
@@ -83,14 +83,15 @@ std::string GccCompilerSupport::compileCppModule(const Pothos::Util::CompilerArg
     Poco::ProcessHandle ph(Poco::Process::launch(
         "g++", args, &inPipe, &outPipe, &outPipe, env));
 
+    //read into output buffer until pipe is closed
+    Poco::PipeInputStream is(outPipe);
+    std::string outBuff;
+    for (std::string line; std::getline(is, line);) outBuff += line;
+
     //handle error case
-    if (ph.wait() != 0)
+    if (ph.wait() != 0 or not Poco::File(outPath.c_str()).exists())
     {
-        Poco::PipeInputStream errStream(outPipe);
-        const std::string errMsgBuff = std::string(
-            std::istreambuf_iterator<char>(errStream),
-            std::istreambuf_iterator<char>());
-        throw Pothos::Exception("GccCompilerSupport::compileCppModule", errMsgBuff);
+        throw Pothos::Exception("GccCompilerSupport::compileCppModule", outBuff);
     }
 
     //return output file path

--- a/lib/Util/Builtin/MsvcCompilerSupport.in.cpp
+++ b/lib/Util/Builtin/MsvcCompilerSupport.in.cpp
@@ -136,7 +136,7 @@ std::string MsvcCompilerSupport::compileCppModule(const Pothos::Util::CompilerAr
     //read into output buffer until pipe is closed
     Poco::PipeInputStream is(outPipe);
     std::string outBuff;
-    for (std::string line; std::getline(is, line);) outBuff += line;
+    for (std::string line; std::getline(is, line);) outBuff += line+'\n';
 
     //handle error case
     if (ph.wait() != 0 or not Poco::File(outPath.c_str()).exists())

--- a/lib/Util/Builtin/MsvcCompilerSupport.in.cpp
+++ b/lib/Util/Builtin/MsvcCompilerSupport.in.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017 Josh Blum
+// Copyright (c) 2014-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Util/Compiler.hpp>
@@ -133,14 +133,15 @@ std::string MsvcCompilerSupport::compileCppModule(const Pothos::Util::CompilerAr
     Poco::ProcessHandle ph(Poco::Process::launch(
         clBatPath, args, nullptr, &outPipe, &outPipe, env));
 
+    //read into output buffer until pipe is closed
+    Poco::PipeInputStream is(outPipe);
+    std::string outBuff;
+    for (std::string line; std::getline(is, line);) outBuff += line;
+
     //handle error case
     if (ph.wait() != 0 or not Poco::File(outPath.c_str()).exists())
     {
-        Poco::PipeInputStream errStream(outPipe);
-        const std::string errMsgBuff = std::string(
-            std::istreambuf_iterator<char>(errStream),
-            std::istreambuf_iterator<char>());
-        throw Pothos::Exception("MsvcCompilerSupport::compileCppModule", errMsgBuff);
+        throw Pothos::Exception("MsvcCompilerSupport::compileCppModule", outBuff);
     }
 
     //return output file path


### PR DESCRIPTION
* closes https://github.com/pothosware/PothosCore/issues/227

fix the hang from the output pipe getting full since there is so much verbose output from the compiler. Eventually the compiler hangs waiting for the output pipe to be drained. The fix is to read the pipe into a string buffer until the process finishes.