### PR TITLE
Fix undefined flags

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,5 +1,10 @@
 This this the changelog file for the Pothos C++ library.
 
+Release 0.7.2 (pending)
+==========================
+
+- undefined linker flags are only used on module builds
+
 Release 0.7.1 (2021-01-24)
 ==========================
 

--- a/cmake/Modules/PothosStandardFlags.cmake
+++ b/cmake/Modules/PothosStandardFlags.cmake
@@ -27,10 +27,6 @@ if(CMAKE_COMPILER_IS_GNUCXX)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
     endif()
 
-    #force a compile-time error when symbols are missing
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
-    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,--no-undefined")
-
     #these warnings are caused by static warnings used throughout the code
     add_compile_options(-Wno-unused-local-typedefs)
 

--- a/cmake/Modules/PothosUtil.cmake
+++ b/cmake/Modules/PothosUtil.cmake
@@ -151,7 +151,7 @@ function(POTHOS_MODULE_UTIL)
     #setup module build and install rules
     include_directories(${Pothos_INCLUDE_DIRS})
     add_library(${POTHOS_MODULE_UTIL_TARGET} MODULE ${POTHOS_MODULE_UTIL_SOURCES})
-    target_link_libraries(${POTHOS_MODULE_UTIL_TARGET} ${Pothos_LIBRARIES} ${POTHOS_MODULE_UTIL_LIBRARIES})
+    target_link_libraries(${POTHOS_MODULE_UTIL_TARGET} PRIVATE ${Pothos_LIBRARIES} ${POTHOS_MODULE_UTIL_LIBRARIES})
     set_target_properties(${POTHOS_MODULE_UTIL_TARGET} PROPERTIES DEBUG_POSTFIX "") #same name in debug mode
 
     if(CMAKE_COMPILER_IS_GNUCXX)

--- a/cmake/Modules/PothosUtil.cmake
+++ b/cmake/Modules/PothosUtil.cmake
@@ -153,6 +153,13 @@ function(POTHOS_MODULE_UTIL)
     add_library(${POTHOS_MODULE_UTIL_TARGET} MODULE ${POTHOS_MODULE_UTIL_SOURCES})
     target_link_libraries(${POTHOS_MODULE_UTIL_TARGET} ${Pothos_LIBRARIES} ${POTHOS_MODULE_UTIL_LIBRARIES})
     set_target_properties(${POTHOS_MODULE_UTIL_TARGET} PROPERTIES DEBUG_POSTFIX "") #same name in debug mode
+
+    if(CMAKE_COMPILER_IS_GNUCXX)
+        #force a compile-time error when symbols are missing
+        #otherwise modules will cause a runtime error on load
+        target_link_libraries(${POTHOS_MODULE_UTIL_TARGET} PRIVATE "-Wl,--no-undefined")
+    endif()
+
     install(
         TARGETS ${POTHOS_MODULE_UTIL_TARGET}
         DESTINATION ${MODULE_DESTINATION}

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends:
     cmake (>= 2.8.9),
     libpoco-dev (>= 1.6),
     libmuparserx-dev,
-    nlohmann-json-dev,
+    nlohmann-json3-dev,
     libnuma-dev [amd64 i386]
 Standards-Version: 4.5.0
 Homepage: https://github.com/pothosware/PothosCore/wiki


### PR DESCRIPTION
* undefined flag only for module linking, not forced on all library users
* should help issues linking with newer python with late loaded symbols
* copy soapysdr style here, similar change
*  debian: update json library name for 20.04
* TODO: fix conflict when merging in master for POTHOS_CMAKE_DIRECTORY
* should fix https://github.com/pothosware/homebrew-pothos/issues/50 after merge into master